### PR TITLE
Iql baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,14 @@ venv/
 
 # Experiment tracking
 wandb/
+logs/
+
+# Local AI assistant / graph context (never commit)
+AGENTS.md
+PROJECT_MAP.md
+.codex/
+.graphifyignore
+graphify-out/
 
 # OS files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ on three core metrics:
 
 | Metric | Description |
 |--------|-------------|
-| **ROI** | Total conversion value won / total budget spent |
+| **Value per Spend** | Total conversion value / total spend (proxy for ROAS when value is scaled conversions) |
 | **Budget Utilization** | Amount spent / total budget available |
 | **Win Rate** | Auctions won / auctions entered |
+
+Notes on naming:
+- AuctionNet reports `reward` and `allCost` in its own evaluation loop. In this repo we treat `reward/allCost` as **value per spend**.
+- In many adtech contexts this is called **ROAS** only when conversion value is true revenue. In our setup, conversion value is typically `reward_value_scale × conversions` (a proxy).
 
 ---
 
@@ -37,15 +41,18 @@ on three core metrics:
 ### Installation
 
 ```bash
-# 1. Clone this repo alongside the AuctionNet sibling repo
-git clone --recurse-submodules https://github.com/YOUR_ORG/rl-ad-bidding.git
+# 1. Clone this repo
+git clone https://github.com/cocoa-huang/rl-ad-bidding.git
 cd rl-ad-bidding
 
-# 2. Create the conda environment with the exact Python version
+# 2. Clone AuctionNet as a sibling directory (expected at ../AuctionNet)
+git clone https://github.com/alimama-tech/AuctionNet.git ../AuctionNet
+
+# 3. Create the conda environment with the exact Python version
 conda create -n rl-ad-bidding python=3.9.12
 conda activate rl-ad-bidding
 
-# 3. Install Python dependencies
+# 4. Install Python dependencies
 pip install -r requirements.txt
 ```
 
@@ -91,6 +98,28 @@ rl-ad-bidding/
 python scripts/train.py --config configs/default.yaml
 ```
 
+### Evaluate AuctionNet pretrained IQL baseline
+
+This evaluates AuctionNet's official pretrained IQL policy under the key knobs
+from a chosen config (budget, ticks, pv_num, player_index).
+
+```bash
+python scripts/evaluate_auctionnet_iql.py --config configs/gcp-run-9-selective.yaml
+```
+
+### Compare PPO vs IQL vs fixed-alpha in one shared simulator loop
+
+This runs all selected policies inside the same AuctionNet simulation loop and
+prints comparable metrics.
+
+```bash
+python scripts/common_policy_eval.py \
+  --config configs/gcp-run-9-selective.yaml \
+  --run-name gcp-run-9-selective \
+  --episodes 48 \
+  --fixed-alphas 50 100 130 150
+```
+
 ### Submit a training job on NYU Greene HPC
 
 ```bash
@@ -120,13 +149,13 @@ The `data/` directory is gitignored — raw data is never committed to this repo
 To generate data:
 
 ```bash
-# Instructions TBD — see AuctionNet sibling repo for data generation scripts
+# See AuctionNet repo for data generation scripts and episode assets.
 ```
 
 To download pre-generated data from shared storage:
 
 ```bash
-# Instructions TBD — link to NYU Google Drive or HPC scratch space
+# Not required for the core AuctionNet NeurIPS PV generator path used in this repo.
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,13 +20,9 @@ on three core metrics:
 
 | Metric | Description |
 |--------|-------------|
-| **Value per Spend** | Total conversion value / total spend (proxy for ROAS when value is scaled conversions) |
+| **ROI** | Total conversion value won / total budget spent |
 | **Budget Utilization** | Amount spent / total budget available |
 | **Win Rate** | Auctions won / auctions entered |
-
-Notes on naming:
-- AuctionNet reports `reward` and `allCost` in its own evaluation loop. In this repo we treat `reward/allCost` as **value per spend**.
-- In many adtech contexts this is called **ROAS** only when conversion value is true revenue. In our setup, conversion value is typically `reward_value_scale × conversions` (a proxy).
 
 ---
 

--- a/agents/ppo_agent.py
+++ b/agents/ppo_agent.py
@@ -8,8 +8,12 @@ can interact with a consistent agent interface.
 Expected usage:
     env = AuctionNetGymEnv(env_config)
     agent = PPOAgent(env.observation_space, env.action_space, agent_config, env=env)
-    agent.update(total_timesteps=50_000)
+    agent.update(total_timesteps=500_000)
     action, _, _ = agent.select_action(obs)
+
+Reference:
+    Schulman, J., Wolski, F., Dhariwal, P., Radford, A., & Klimov, O. (2017).
+    Proximal Policy Optimization Algorithms. arXiv:1707.06347.
 """
 
 from __future__ import annotations
@@ -19,10 +23,16 @@ from typing import Any, Optional
 
 import numpy as np
 from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import VecNormalize
 
 
 class PPOAgent:
-    """Thin wrapper around stable_baselines3.PPO."""
+    """Thin wrapper around stable_baselines3.PPO.
+
+    Attributes:
+        config (dict): Hyperparameters from configs/YAML under the 'agent' section.
+        model (PPO | None): The underlying SB3 PPO model. None until an env is attached.
+    """
 
     def __init__(
         self,
@@ -31,15 +41,21 @@ class PPOAgent:
         config: dict,
         env=None,
     ):
-        """
-        Initialize the SB3 PPO model.
+        """Initialize the SB3 PPO model.
 
         Args:
             observation_space: Gymnasium observation space. Kept for interface
-                consistency, even though SB3 primarily needs `env`.
+                consistency; SB3 derives input dims from `env` directly.
             action_space: Gymnasium action space. Kept for interface consistency.
             config (dict): Hyperparameters from configs/default.yaml under 'agent'.
             env: Gymnasium-compatible environment or VecEnv. Required for training.
+                NOTE: The action space [0, max_bid_multiplier] is non-symmetric
+                around 0 because competitors bid cpa * pValue with CPA in [60, 130],
+                requiring our agent to reach up to 150. SB3's Gaussian policy
+                initializes near 0, so ~half of early samples are clipped to 0 and
+                wasted. Fix: pass policy_kwargs={"squash_output": True} in
+                scripts/train.py, which applies tanh + rescale to guarantee every
+                sampled action lands in [0, max_bid_multiplier] from step one.
         """
         self.observation_space = observation_space
         self.action_space = action_space
@@ -51,142 +67,201 @@ class PPOAgent:
         self.device = config.get("device", "auto")
         self.tensorboard_log = config.get("tensorboard_log", None)
 
-        # Core PPO hyperparameters
+        # Core PPO hyperparameters.
+        # n_steps=384 = 48 ticks/episode × 8 envs — keeps GAE within complete episodes.
         self.learning_rate = float(config.get("lr", 3e-4))
-        self.n_steps = int(config.get("n_steps", 2048))
-        self.batch_size = int(config.get("batch_size", 64))
+        self.n_steps = int(config.get("n_steps", 384))
+        self.batch_size = int(config.get("batch_size", 128))
         self.n_epochs = int(config.get("n_epochs", 10))
         self.gamma = float(config.get("gamma", 0.99))
         self.gae_lambda = float(config.get("gae_lambda", 0.95))
         self.clip_range = float(config.get("clip_range", 0.2))
-        self.ent_coef = float(config.get("ent_coef", 0.0))
+        # ent_coef=0.01: exploration bonus needed for continuous [0, max_bid_multiplier]
+        # action space; 0.0 causes the policy to collapse to a narrow region early.
+        self.ent_coef = float(config.get("ent_coef", 0.01))
         self.vf_coef = float(config.get("vf_coef", 0.5))
         self.max_grad_norm = float(config.get("max_grad_norm", 0.5))
         self.seed = config.get("seed", None)
 
-        # Optional policy network structure
-        policy_kwargs = config.get("policy_kwargs", None)
-
         self.model: Optional[PPO] = None
         if env is not None:
-            self.model = PPO(
-                policy=self.policy,
-                env=env,
-                learning_rate=self.learning_rate,
-                n_steps=self.n_steps,
-                batch_size=self.batch_size,
-                n_epochs=self.n_epochs,
-                gamma=self.gamma,
-                gae_lambda=self.gae_lambda,
-                clip_range=self.clip_range,
-                ent_coef=self.ent_coef,
-                vf_coef=self.vf_coef,
-                max_grad_norm=self.max_grad_norm,
-                verbose=self.verbose,
-                seed=self.seed,
-                device=self.device,
-                tensorboard_log=self.tensorboard_log,
-                policy_kwargs=policy_kwargs,
-            )
+            self.model = self._build_model(env)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_model(self, env) -> PPO:
+        """Construct and return a fresh SB3 PPO instance for the given env."""
+        return PPO(
+            policy=self.policy,
+            env=env,
+            learning_rate=self.learning_rate,
+            n_steps=self.n_steps,
+            batch_size=self.batch_size,
+            n_epochs=self.n_epochs,
+            gamma=self.gamma,
+            gae_lambda=self.gae_lambda,
+            clip_range=self.clip_range,
+            ent_coef=self.ent_coef,
+            vf_coef=self.vf_coef,
+            max_grad_norm=self.max_grad_norm,
+            verbose=self.verbose,
+            seed=self.seed,
+            device=self.device,
+            tensorboard_log=self.tensorboard_log,
+            policy_kwargs=self.config.get("policy_kwargs", None),
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def set_env(self, env) -> None:
-        """Attach or replace the environment."""
+        """Attach or replace the training environment.
+
+        If no model exists yet, builds one. Otherwise delegates to SB3's set_env.
+        """
         self.env = env
         if self.model is None:
-            self.model = PPO(
-                policy=self.policy,
-                env=env,
-                learning_rate=self.learning_rate,
-                n_steps=self.n_steps,
-                batch_size=self.batch_size,
-                n_epochs=self.n_epochs,
-                gamma=self.gamma,
-                gae_lambda=self.gae_lambda,
-                clip_range=self.clip_range,
-                ent_coef=self.ent_coef,
-                vf_coef=self.vf_coef,
-                max_grad_norm=self.max_grad_norm,
-                verbose=self.verbose,
-                seed=self.seed,
-                device=self.device,
-                tensorboard_log=self.tensorboard_log,
-                policy_kwargs=self.config.get("policy_kwargs", None),
-            )
+            self.model = self._build_model(env)
         else:
             self.model.set_env(env)
 
     def select_action(self, observation, deterministic: bool = False):
-        """
-        Predict an action from the current policy.
+        """Predict an action from the current policy.
 
         Args:
             observation (np.ndarray): Current observation.
             deterministic (bool): Whether to use deterministic policy output.
 
         Returns:
-            action (np.ndarray): Predicted action.
-            log_prob: Not exposed directly by SB3's public `predict` API, so None.
-            value: Not exposed directly by SB3's public `predict` API, so None.
+            action (np.ndarray): Predicted action (bid multiplier).
+            None: log_prob — not exposed by SB3's public predict() API.
+            None: value   — not exposed by SB3's public predict() API.
         """
         if self.model is None:
             raise ValueError("PPO model is not initialized. Call set_env(env) first.")
-
         obs = np.asarray(observation, dtype=np.float32)
         action, _states = self.model.predict(obs, deterministic=deterministic)
         return action, None, None
 
     def update(self, rollout_buffer=None, total_timesteps: Optional[int] = None, **learn_kwargs):
-        """
-        Train the SB3 PPO model.
+        """Train the SB3 PPO model via model.learn().
 
-        Since PPO is delegated to SB3, `rollout_buffer` is ignored. Training is
-        performed by calling `learn()`.
+        `rollout_buffer` is ignored — SB3 manages its own rollout buffer internally.
 
         Args:
-            rollout_buffer: Ignored. Kept only for backward compatibility.
-            total_timesteps (int): Number of timesteps to train for.
-            **learn_kwargs: Extra keyword arguments passed to `model.learn()`.
+            rollout_buffer: Ignored. Kept only for interface compatibility.
+            total_timesteps (int): Number of environment steps to train for.
+                Defaults to config['total_timesteps'] or 500_000.
+            **learn_kwargs: Extra keyword arguments forwarded to model.learn().
 
         Returns:
-            dict: Minimal diagnostics.
+            dict: {'trained_timesteps': int}
+        """
+        if self.model is None:
+            raise ValueError("PPO model is not initialized. Call set_env(env) first.")
+        if total_timesteps is None:
+            total_timesteps = int(self.config.get("total_timesteps", 500_000))
+        self.model.learn(total_timesteps=total_timesteps, **learn_kwargs)
+        return {"trained_timesteps": total_timesteps}
+
+    def evaluate(self, env, n_eval_episodes: int = 10) -> dict:
+        """Run deterministic rollouts and return RTB-specific evaluation metrics.
+
+        This is distinct from SB3's internal EvalCallback, which only tracks
+        ep_rew_mean. This method computes the domain metrics needed to compare
+        agents in the research paper: ROI, budget utilization, and win rate.
+
+        Args:
+            env: A single (non-vectorized) AuctionNetGymEnv instance.
+                Must not be wrapped with VecNormalize — pass the raw env so
+                that info dict values are in original units.
+            n_eval_episodes (int): Number of complete episodes to roll out.
+
+        Returns:
+            dict with keys:
+                roi (float): total conversion value / total cost.
+                    Higher is better. 0.0 if agent spent nothing.
+                budget_utilization (float): total cost / (n_eval_episodes * budget).
+                    Target ~0.90–1.0.
+                win_rate (float): total auctions won / total auctions entered.
         """
         if self.model is None:
             raise ValueError("PPO model is not initialized. Call set_env(env) first.")
 
-        if total_timesteps is None:
-            total_timesteps = int(self.config.get("total_timesteps", 10_000))
+        total_conversion_value = 0.0
+        total_cost = 0.0
+        total_won = 0
+        total_auctions = 0
+        budget = env.budget
 
-        self.model.learn(total_timesteps=total_timesteps, **learn_kwargs)
-        return {"trained_timesteps": total_timesteps}
+        for _ in range(n_eval_episodes):
+            obs, _ = env.reset()
+            terminated = truncated = False
+            while not (terminated or truncated):
+                action, _, _ = self.select_action(obs, deterministic=True)
+                obs, _reward, terminated, truncated, info = env.step(action)
+                total_conversion_value += info["conversion_value"]
+                total_cost += info["cost"]
+                total_won += info["won"]
+                total_auctions += info.get("total_pvs", env._pv_gen.pv_values[0].shape[0])
+
+        roi = total_conversion_value / total_cost if total_cost > 0 else 0.0
+        budget_utilization = total_cost / (n_eval_episodes * budget)
+        win_rate = total_won / total_auctions if total_auctions > 0 else 0.0
+
+        return {
+            "roi": roi,
+            "budget_utilization": budget_utilization,
+            "win_rate": win_rate,
+        }
 
     def save(self, path: str):
-        """
-        Save the SB3 model checkpoint.
+        """Save the SB3 model checkpoint to disk.
+
+        If the training env is a VecNormalize wrapper, its running statistics
+        (observation mean/var, reward mean/var) are saved as a sidecar file at
+        '<path>_vecnormalize.pkl'. Both files must be present to restore a
+        correctly functioning policy at inference time.
 
         Args:
-            path (str): Save path, e.g. 'saved_models/ppo_agent'.
-                SB3 will add '.zip' if needed.
+            path (str): Save path without extension, e.g. 'saved_models/ppo_run1'.
+                SB3 appends '.zip' to the model file automatically.
         """
         if self.model is None:
             raise ValueError("PPO model is not initialized. Nothing to save.")
-
         save_path = Path(path)
         save_path.parent.mkdir(parents=True, exist_ok=True)
         self.model.save(str(save_path))
+        if isinstance(self.env, VecNormalize):
+            self.env.save(str(save_path) + "_vecnormalize.pkl")
 
     def load(self, path: str, env=None):
-        """
-        Load a saved SB3 PPO model.
+        """Load a saved SB3 PPO checkpoint.
+
+        If a VecNormalize sidecar file ('<path>_vecnormalize.pkl') exists and
+        the provided env is a VecNormalize instance, the saved running statistics
+        are restored into it before attaching it to the model. This ensures
+        observations are scaled identically to how they were during training.
 
         Args:
-            path (str): Path to checkpoint.
-            env: Optional env to attach after loading.
+            path (str): Path to the checkpoint (with or without '.zip').
+            env: Optional environment to attach after loading. Pass a
+                VecNormalize-wrapped env to trigger stats restoration.
 
         Returns:
             PPOAgent: self
         """
         if env is not None:
             self.env = env
+
+        vecnorm_path = str(Path(path)) + "_vecnormalize.pkl"
+        if isinstance(self.env, VecNormalize) and Path(vecnorm_path).exists():
+            self.env = VecNormalize.load(vecnorm_path, self.env.venv)
+            self.env.training = False
+            self.env.norm_reward = False
 
         self.model = PPO.load(path, env=self.env, device=self.device)
         return self

--- a/agents/ppo_agent.py
+++ b/agents/ppo_agent.py
@@ -195,18 +195,25 @@ class PPOAgent:
         total_cost = 0.0
         total_won = 0
         total_auctions = 0
+        ep_rewards = []
         budget = env.budget
 
         for _ in range(n_eval_episodes):
             obs, _ = env.reset()
             terminated = truncated = False
+            ep_rew = 0.0
             while not (terminated or truncated):
-                action, _, _ = self.select_action(obs, deterministic=True)
-                obs, _reward, terminated, truncated, info = env.step(action)
+                policy_obs = obs
+                if isinstance(self.env, VecNormalize):
+                    policy_obs = self.env.normalize_obs(np.asarray(obs, dtype=np.float32))
+                action, _states = self.model.predict(policy_obs, deterministic=True)
+                obs, reward, terminated, truncated, info = env.step(action)
+                ep_rew += reward
                 total_conversion_value += info["conversion_value"]
                 total_cost += info["cost"]
                 total_won += info["won"]
                 total_auctions += info.get("total_pvs", env._pv_gen.pv_values[0].shape[0])
+            ep_rewards.append(ep_rew)
 
         roi = total_conversion_value / total_cost if total_cost > 0 else 0.0
         budget_utilization = total_cost / (n_eval_episodes * budget)
@@ -216,6 +223,8 @@ class PPOAgent:
             "roi": roi,
             "budget_utilization": budget_utilization,
             "win_rate": win_rate,
+            "ep_rew_mean": float(np.mean(ep_rewards)) if ep_rewards else 0.0,
+            "ep_rew_std": float(np.std(ep_rewards, ddof=1)) if len(ep_rewards) > 1 else 0.0,
         }
 
     def save(self, path: str):

--- a/agents/ppo_agent.py
+++ b/agents/ppo_agent.py
@@ -257,7 +257,11 @@ class PPOAgent:
         if env is not None:
             self.env = env
 
-        vecnorm_path = str(Path(path)) + "_vecnormalize.pkl"
+        # Strip .zip so the sidecar path is consistent with save() regardless of
+        # whether the caller passed "best_model" or "best_model.zip".
+        p = Path(path)
+        base_path = str(p.with_suffix("")) if p.suffix == ".zip" else str(p)
+        vecnorm_path = base_path + "_vecnormalize.pkl"
         if isinstance(self.env, VecNormalize) and Path(vecnorm_path).exists():
             self.env = VecNormalize.load(vecnorm_path, self.env.venv)
             self.env.training = False

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -6,7 +6,7 @@ environment:
   max_bid_multiplier: 150.0   # competitors bid cpa * pValues, cpa range is 60-130
                               # Action space is [-1, 1]; rescaled to [0, max_bid_multiplier] in step()
   auctionnet_path: ../AuctionNet
-  pv_num: 500000
+  pv_num: 50000
   min_remaining_budget: 0.1
   reward_lambda_cost: 0.0        # set to 0 — cost penalised implicitly via budget termination
   reward_alpha_utilization: 50.0 # terminal bonus = alpha * (total_spend / budget); needs tuning

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -38,4 +38,5 @@ training:
 logging:
   use_wandb: true
   project_name: rl-ad-bidding
-  run_name: baseline
+  entity: models-new-york-university8717
+  run_name: eric-value-utilization-bonus

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -4,8 +4,7 @@ environment:
   num_episode: 48           # episodes available in the dataset (cycles 0-47)
   player_index: 0
   max_bid_multiplier: 150.0   # competitors bid cpa * pValues, cpa range is 60-130
-                              # NOTE: action space [0, 150] is non-symmetric around 0.
-                              # Fix: policy_kwargs={"squash_output": True} in scripts/train.py
+                              # Action space is [-1, 1]; rescaled to [0, max_bid_multiplier] in step()
   auctionnet_path: ../AuctionNet
   pv_num: 500000
   min_remaining_budget: 0.1

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -30,8 +30,10 @@ agent:
 
 training:
   n_episodes: 1000
+  n_envs: 8                 # SubprocVecEnv workers; n_steps=384 is tuned for this value
   eval_interval: 100
   save_interval: 500
+  early_stop_patience: 10   # evals without improvement before halting
 
 logging:
   use_wandb: true

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -9,13 +9,24 @@ environment:
   auctionnet_path: ../AuctionNet
   pv_num: 500000
   min_remaining_budget: 0.1
-  reward_lambda_cost: 1.0 # Cost penalty coefficient for reward shaping
+  reward_lambda_cost: 0.0        # set to 0 — cost penalised implicitly via budget termination
+  reward_alpha_utilization: 50.0 # terminal bonus = alpha * (total_spend / budget); needs tuning
 
 agent:
   algorithm: ppo
+  policy: MlpPolicy
   lr: 3e-4
+  n_steps: 384          # 48 ticks × 8 envs — keeps GAE within complete episodes
+  batch_size: 128
+  n_epochs: 10
   gamma: 0.99
-  batch_size: 64
+  gae_lambda: 0.95
+  clip_range: 0.2
+  ent_coef: 0.01        # exploration bonus; 0.0 causes collapse on [0, 150] action space
+  vf_coef: 0.5
+  max_grad_norm: 0.5
+  total_timesteps: 500000
+  device: cpu
 
 training:
   n_episodes: 1000

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -38,5 +38,5 @@ training:
 logging:
   use_wandb: true
   project_name: rl-ad-bidding
-  entity: models-new-york-university8717
+  entity: sp9019-nyu
   run_name: eric-value-utilization-bonus

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -4,6 +4,8 @@ environment:
   num_episode: 48           # episodes available in the dataset (cycles 0-47)
   player_index: 0
   max_bid_multiplier: 150.0   # competitors bid cpa * pValues, cpa range is 60-130
+                              # NOTE: action space [0, 150] is non-symmetric around 0.
+                              # Fix: policy_kwargs={"squash_output": True} in scripts/train.py
   auctionnet_path: ../AuctionNet
   pv_num: 500000
   min_remaining_budget: 0.1

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -8,8 +8,9 @@ environment:
   auctionnet_path: ../AuctionNet
   pv_num: 50000
   min_remaining_budget: 0.1
-  reward_lambda_cost: 0.0        # set to 0 — cost penalised implicitly via budget termination
-  reward_alpha_utilization: 50.0 # terminal bonus = alpha * (total_spend / budget); needs tuning
+  reward_lambda_cost: 0.0        # 0 = pure value reward; 1.0 = full profit reward
+  reward_alpha_utilization: 0.0  # deprecated — use reward_beta_pacing instead
+  reward_beta_pacing: 2.0        # per-step pacing weight: r_t += beta * (cost_t / budget)
 
 agent:
   algorithm: ppo
@@ -38,4 +39,4 @@ logging:
   use_wandb: true
   project_name: rl-ad-bidding
   entity: sp9019-nyu
-  run_name: eric-value-utilization-bonus
+  run_name: eric-dense-pacing

--- a/configs/diagnostic_budget150.yaml
+++ b/configs/diagnostic_budget150.yaml
@@ -1,0 +1,24 @@
+# Diagnostic config: same as gcp-run-5 but player budget reduced to $150.
+# Tests Path B hypothesis — that the ~5% utilization ceiling at $2900 budget
+# is purely a budget-arithmetic artifact (player wins ~6% × $0.05/win × 50k PVs
+# ≈ $150 spend regardless of strategy), not a learnable RL constraint.
+#
+# At budget=$150, the same per-α spend ($54/$107/$140 at α=50/100/130) maps to
+# 36% / 71% / 93% utilization — a regime where pacing reward is genuinely
+# active and PPO has a real gradient between strategies.
+#
+# Use only with scripts/quick_eval.py --alpha-override; not for training yet.
+
+environment:
+  budget: 150                   # CHANGED from 2900 — sole experimental variable
+  num_ticks: 48
+  num_episode: 48
+  player_index: 0               # back to default — Path A confirmed CPA isn't the issue
+  max_bid_multiplier: 150.0
+  auctionnet_path: ../AuctionNet
+  pv_num: 50000
+  min_remaining_budget: 0.1
+  reward_value_scale: 100.0     # unchanged — CPA for player_index=0
+  reward_lambda_cost: 1.0
+  reward_alpha_utilization: 0.0
+  reward_beta_pacing: 3.0

--- a/configs/diagnostic_p5.yaml
+++ b/configs/diagnostic_p5.yaml
@@ -1,0 +1,18 @@
+# Diagnostic config: same as gcp-run-5 but player_index=5 (CPA=130, category 0).
+# Used only with scripts/quick_eval.py --alpha-override to test whether the
+# ~5% utilization ceiling observed at player_index=0 is CPA-driven.
+# Not for training.
+
+environment:
+  budget: 2900                  # held constant vs gcp-run-5 to isolate player_index effect
+  num_ticks: 48
+  num_episode: 48
+  player_index: 5               # CPA=130, same category as player_index=0 (CPA=100)
+  max_bid_multiplier: 150.0
+  auctionnet_path: ../AuctionNet
+  pv_num: 50000
+  min_remaining_budget: 0.1
+  reward_value_scale: 100.0     # held constant vs gcp-run-5 so ep_rew_mean is comparable
+  reward_lambda_cost: 1.0
+  reward_alpha_utilization: 0.0
+  reward_beta_pacing: 3.0

--- a/configs/gcp-run-5.yaml
+++ b/configs/gcp-run-5.yaml
@@ -1,0 +1,42 @@
+environment:
+  budget: 2900
+  num_ticks: 48
+  num_episode: 48
+  player_index: 0
+  max_bid_multiplier: 150.0
+  auctionnet_path: ../AuctionNet
+  pv_num: 50000
+  min_remaining_budget: 0.1
+  reward_value_scale: 100.0     # scale conversion value to match cost units (CPA=100 for player 0)
+  reward_lambda_cost: 1.0       # profit: penalize cost fully
+  reward_alpha_utilization: 0.0 # deprecated
+  reward_beta_pacing: 3.0       # pacing: r += beta * min(pacing_ratio, 1.0)
+
+agent:
+  algorithm: ppo
+  policy: MlpPolicy
+  lr: 3e-4
+  n_steps: 384
+  batch_size: 128
+  n_epochs: 10
+  gamma: 0.99
+  gae_lambda: 0.95
+  clip_range: 0.2
+  ent_coef: 0.01
+  vf_coef: 0.5
+  max_grad_norm: 0.5
+  total_timesteps: 1000000
+  device: cpu
+
+training:
+  n_episodes: 1000
+  n_envs: 8
+  eval_interval: 100
+  save_interval: 500
+  early_stop_patience: 10
+
+logging:
+  use_wandb: true
+  project_name: rl-ad-bidding
+  entity: sp9019-nyu
+  run_name: gcp-run-5

--- a/configs/gcp-run-6.yaml
+++ b/configs/gcp-run-6.yaml
@@ -1,0 +1,42 @@
+environment:
+  budget: 2900
+  num_ticks: 48
+  num_episode: 48
+  player_index: 0
+  max_bid_multiplier: 150.0
+  auctionnet_path: ../AuctionNet
+  pv_num: 50000
+  min_remaining_budget: 0.1
+  reward_value_scale: 100.0     # unchanged from gcp-run-5
+  reward_lambda_cost: 1.0       # unchanged from gcp-run-5
+  reward_alpha_utilization: 0.0 # deprecated
+  reward_beta_pacing: 3.0       # unchanged from gcp-run-5
+
+agent:
+  algorithm: ppo
+  policy: MlpPolicy
+  lr: 3e-4
+  n_steps: 4096        # was 384 — 32K env steps/update (~680 ep) to escape advantage noise floor
+  batch_size: 64       # was 128 — more grad steps per epoch given the larger rollout
+  n_epochs: 10
+  gamma: 0.99
+  gae_lambda: 0.95
+  clip_range: 0.2
+  ent_coef: 0.0        # was 0.01 — entropy bonus was pinning policy std at init
+  vf_coef: 0.5
+  max_grad_norm: 0.5
+  total_timesteps: 1000000
+  device: cpu
+
+training:
+  n_episodes: 1000
+  n_envs: 8            # matched to e2-standard-8 vCPU count; do not oversubscribe
+  eval_interval: 100
+  save_interval: 500
+  early_stop_patience: 10
+
+logging:
+  use_wandb: true
+  project_name: rl-ad-bidding
+  entity: sp9019-nyu
+  run_name: gcp-run-6

--- a/configs/gcp-run-7.yaml
+++ b/configs/gcp-run-7.yaml
@@ -1,0 +1,55 @@
+# gcp-run-7 — first training run in the budget-binding regime.
+#
+# Combines:
+#   - environment from diagnostic_budget150.yaml (Path B): budget=$150
+#     reframes the env so utilization is meaningful and PPO has a real
+#     reward gradient. α-sweep at this budget showed an inverted-U landscape
+#     with peak ep_rew_mean ≈ 317 at α=100, ≈ 147 at α=50, ≈ 201 at α=130.
+#   - agent block from gcp-run-6.yaml (PPO sizing/entropy fix): n_steps=4096,
+#     batch_size=64, ent_coef=0; sized for the GCP VM's 8 vCPUs.
+#
+# This is the first run where PPO has both (a) a learnable gradient AND
+# (b) hyperparameters sized to extract it. gcp-run-5 had neither.
+
+environment:
+  budget: 150                   # binding constraint — pacing now matters
+  num_ticks: 48
+  num_episode: 48
+  player_index: 0
+  max_bid_multiplier: 150.0     # max α just barely overspends — creates pacing pressure
+  auctionnet_path: ../AuctionNet
+  pv_num: 50000
+  min_remaining_budget: 0.1
+  reward_value_scale: 100.0     # CPA for player_index=0
+  reward_lambda_cost: 1.0
+  reward_alpha_utilization: 0.0
+  reward_beta_pacing: 3.0
+
+agent:
+  algorithm: ppo
+  policy: MlpPolicy
+  lr: 3e-4
+  n_steps: 4096        # 4096 × 8 envs = 32K env steps (~680 ep) per PPO update
+  batch_size: 64       # ~5K grad steps/update at 10 epochs
+  n_epochs: 10
+  gamma: 0.99
+  gae_lambda: 0.95
+  clip_range: 0.2
+  ent_coef: 0.0        # let policy commit; previous 0.01 pinned std at init
+  vf_coef: 0.5
+  max_grad_norm: 0.5
+  total_timesteps: 1000000
+  device: cpu
+
+training:
+  n_episodes: 1000
+  n_envs: 8            # matched to e2-standard-8 vCPU count
+  eval_interval: 100
+  save_interval: 500
+  early_stop_patience: 10
+
+logging:
+  use_wandb: true
+  project_name: rl-ad-bidding
+  entity: sp9019-nyu
+  run_name: gcp-run-7

--- a/configs/gcp-run-8.yaml
+++ b/configs/gcp-run-8.yaml
@@ -1,0 +1,84 @@
+# gcp-run-8 — stabilised training on the budget-binding regime.
+#
+# Addresses three root causes identified from gcp-run-7's W&B logs:
+#
+#   1. Flat value loss (~1600 throughout, never decreasing)
+#      Root cause: VecNormalize was wired into save/load but never instantiated
+#      in train.py. The critic was fitting raw dollar-scale targets (variance ~1600²)
+#      instead of unit-normalised targets. Fix: norm_reward: true.
+#
+#   2. Premature policy convergence (PG loss → 0 at step 300K, eval oscillating 182–476)
+#      Root cause: ent_coef=0.0 left no mechanism to escape the local optimum the
+#      policy committed to early. Fix: ent_coef: 0.01 — small enough that std won't be
+#      pinned at init (that required ent_coef=0.01 AND no gradient, which is gcp-run-5's
+#      condition; we have a real gradient here), large enough to prevent lock-in.
+#
+#   3. Policy network capacity (SB3 default [64,64] for a 48-tick pacing problem)
+#      Root cause: the value function needs to track budget_frac × time_frac × pacing_ratio
+#      interactions across 48 ticks. [64,64] is insufficient. Fix: [256,256] for both
+#      pi and vf — same as Sahil's v3_dense_rewards, the only structural choice in his
+#      run that was independently justified.
+#
+# Unchanged from gcp-run-7:
+#   - budget=150 (validated binding, util jumped from 5% → 54%)
+#   - reward formula (100*value - cost + 3*min(pacing_ratio,1.0)) — peaked at 476 vs
+#     fixed-α=100 ceiling of 317; formula has headroom, don't change it
+#   - n_steps=4096, batch_size=64, n_epochs=10, gamma=0.99, gae_lambda=0.95
+#   - n_envs=8 (matched to e2-standard-8 vCPUs)
+#
+# NOT taken from Sahil's v3_dense_rewards:
+#   - Curriculum learning: his agent crashed to ep_rew_mean=-1000 once curriculum
+#     reached full scale. At budget=150 the gradient already exists; curriculum delays
+#     exposure to the real problem.
+#   - min_bid_multiplier=80: prevents learning conservative pacing when budget is low.
+#   - ent_coef=0.05: too aggressive; his policy never stabilised.
+#   - budget=2900: structurally unlearnable (~5% util ceiling at player_index=0).
+
+environment:
+  budget: 150                   # binding constraint — validated in gcp-run-7
+  num_ticks: 48
+  num_episode: 48
+  player_index: 0
+  max_bid_multiplier: 150.0
+  auctionnet_path: ../AuctionNet
+  pv_num: 50000
+  min_remaining_budget: 0.1
+  reward_value_scale: 100.0     # CPA for player_index=0
+  reward_lambda_cost: 1.0
+  reward_alpha_utilization: 0.0
+  reward_beta_pacing: 3.0
+
+agent:
+  algorithm: ppo
+  policy: MlpPolicy
+  lr: 1e-4              # was 3e-4 — reduced to prevent overshooting on high-variance rewards
+  n_steps: 4096
+  batch_size: 64
+  n_epochs: 10
+  gamma: 0.99
+  gae_lambda: 0.95
+  clip_range: 0.2
+  ent_coef: 0.01        # was 0.0 — prevents premature convergence without pinning std at init
+  vf_coef: 0.5
+  max_grad_norm: 0.5
+  total_timesteps: 2000000      # was 1M — rollout trend was still positive at step 786K
+  device: cpu
+  policy_kwargs:
+    net_arch:
+      pi: [256, 256]    # was SB3 default [64,64]
+      vf: [256, 256]
+
+training:
+  n_episodes: 1000
+  n_envs: 8
+  eval_interval: 100
+  n_eval_episodes: 20           # was 5 — budget=150 has high per-episode variance; 20 gives stable signal
+  save_interval: 500
+  early_stop_patience: 10
+  norm_reward: true             # enables VecNormalize with norm_reward=True — fixes flat value loss
+
+logging:
+  use_wandb: true
+  project_name: rl-ad-bidding
+  entity: sp9019-nyu
+  run_name: gcp-run-8

--- a/configs/gcp-run-9-selective.yaml
+++ b/configs/gcp-run-9-selective.yaml
@@ -1,0 +1,67 @@
+# gcp-run-9-selective — action-space test after gcp-run-8.
+#
+# Hypothesis:
+#   gcp-run-8 likely reached the ceiling of scalar-alpha PPO. The policy can
+#   only move all bids up/down together, so it cannot express "skip low-pValue
+#   PVs and preserve budget for better opportunities." This run keeps the
+#   gcp-run-8 environment, reward, and PPO stabilization package fixed, and
+#   changes only the action space.
+#
+# Action mode:
+#   action[0] in [-1, 1] -> alpha in [0, max_bid_multiplier]
+#   action[1] in [-1, 1] -> keep_fraction in [min_keep_fraction, 1]
+#
+# The env bids alpha * pValue only on the top keep_fraction of PVs within the
+# current tick, ranked by this player's pValue. Fixed-alpha baselines remain
+# comparable because quick_eval maps them to keep_fraction=1.0.
+
+environment:
+  budget: 150
+  num_ticks: 48
+  num_episode: 48
+  player_index: 0
+  max_bid_multiplier: 150.0
+  auctionnet_path: ../AuctionNet
+  pv_num: 50000
+  min_remaining_budget: 0.1
+  reward_value_scale: 100.0
+  reward_lambda_cost: 1.0
+  reward_alpha_utilization: 0.0
+  reward_beta_pacing: 3.0
+  action_mode: selective_topk
+  min_keep_fraction: 0.05
+
+agent:
+  algorithm: ppo
+  policy: MlpPolicy
+  lr: 1e-4
+  n_steps: 4096
+  batch_size: 64
+  n_epochs: 10
+  gamma: 0.99
+  gae_lambda: 0.95
+  clip_range: 0.2
+  ent_coef: 0.01
+  vf_coef: 0.5
+  max_grad_norm: 0.5
+  total_timesteps: 2000000
+  device: cpu
+  policy_kwargs:
+    net_arch:
+      pi: [256, 256]
+      vf: [256, 256]
+
+training:
+  n_episodes: 1000
+  n_envs: 8
+  eval_interval: 100
+  n_eval_episodes: 20
+  save_interval: 500
+  early_stop_patience: 25
+  norm_reward: true
+
+logging:
+  use_wandb: true
+  project_name: rl-ad-bidding
+  entity: sp9019-nyu
+  run_name: gcp-run-9-selective

--- a/environment/gym_wrapper.py
+++ b/environment/gym_wrapper.py
@@ -216,8 +216,8 @@ class AuctionNetGymEnv(gymnasium.Env):
             dtype=np.float32,
         )
         self.action_space = Box(
-            low=np.array([0.0], dtype=np.float32),
-            high=np.array([self.max_bid_multiplier], dtype=np.float32),
+            low=np.array([-1.0], dtype=np.float32),
+            high=np.array([1.0], dtype=np.float32),
             dtype=np.float32,
         )
 
@@ -307,7 +307,8 @@ class AuctionNetGymEnv(gymnasium.Env):
             truncated (bool)
             info (dict)
         """
-        alpha = float(np.clip(action, 0.0, self.max_bid_multiplier))
+        action_clipped = float(np.clip(action, -1.0, 1.0))
+        alpha = ((action_clipped + 1.0) / 2.0) * self.max_bid_multiplier
 
         pv_values = self._pv_gen.pv_values[self._tick]         # (n_pv, 48)
         pvalue_sigmas = self._pv_gen.pValueSigmas[self._tick]  # (n_pv, 48)

--- a/environment/gym_wrapper.py
+++ b/environment/gym_wrapper.py
@@ -185,6 +185,7 @@ class AuctionNetGymEnv(gymnasium.Env):
         self.max_bid_multiplier = float(config["max_bid_multiplier"])
         self.pv_num = int(config["pv_num"])
         self.min_remaining_budget = float(config["min_remaining_budget"])
+        self.reward_value_scale = float(config.get("reward_value_scale", 1.0))
         self.reward_lambda_cost = float(config.get("reward_lambda_cost", 1.0))
         self.reward_alpha_utilization = float(config.get("reward_alpha_utilization", 0.0))
         self.reward_beta_pacing = float(config.get("reward_beta_pacing", 0.0))
@@ -385,9 +386,13 @@ class AuctionNetGymEnv(gymnasium.Env):
         # --- compute reward ---
         player_conversion_value = float(conversion_action_pit[p].sum())  # this tick only
         player_cost = float(real_cost[p])
-        reward = (player_conversion_value
+        # pacing_ratio after this tick: spend_frac / time_frac_elapsed
+        # uses tick+1 so time_frac is never zero (we just completed tick self._tick)
+        _time_frac = (self._tick + 1) / self.num_ticks
+        _pacing_ratio = (self._total_spend / self.budget) / _time_frac
+        reward = (self.reward_value_scale * player_conversion_value
                   - self.reward_lambda_cost * player_cost
-                  + self.reward_beta_pacing * (player_cost / self.budget))
+                  + self.reward_beta_pacing * min(_pacing_ratio, 1.0))
 
         # --- track least winning cost and win rate ---
         self._last_lwc = float(lwc_pit.mean())  # average market clearing price

--- a/environment/gym_wrapper.py
+++ b/environment/gym_wrapper.py
@@ -186,6 +186,7 @@ class AuctionNetGymEnv(gymnasium.Env):
         self.pv_num = int(config["pv_num"])
         self.min_remaining_budget = float(config["min_remaining_budget"])
         self.reward_lambda_cost = float(config.get("reward_lambda_cost", 1.0))
+        self.reward_alpha_utilization = float(config.get("reward_alpha_utilization", 0.0))
 
         # --- import AuctionNet modules (after path is set) ---
         from simul_bidding_env.Environment.BiddingEnv import BiddingEnv
@@ -370,7 +371,9 @@ class AuctionNetGymEnv(gymnasium.Env):
             if agent is not None and i != p:
                 agent.remaining_budget -= real_cost[i]
 
-        # --- compute reward: conversion value - cost (player only) ---
+        # --- compute reward ---
+        # Per-step: conversion value won minus optional cost penalty.
+        # Terminal: optional budget utilization bonus to encourage full spend.
         player_conversion_value = float(conversion_action_pit[p].sum())
         player_cost = float(real_cost[p])
         reward = player_conversion_value - self.reward_lambda_cost * player_cost
@@ -403,6 +406,9 @@ class AuctionNetGymEnv(gymnasium.Env):
         )
         truncated = False
 
+        if terminated and self.reward_alpha_utilization > 0.0:
+            reward += self.reward_alpha_utilization * (self._total_spend / self.budget)
+
         # --- fetch next tick PV data for observation (if episode continues) ---
         if not terminated:
             self._current_pv_values = self._pv_gen.pv_values[self._tick]
@@ -412,6 +418,7 @@ class AuctionNetGymEnv(gymnasium.Env):
 
         info = {
             "won": n_won,
+            "total_pvs": n_total,
             "cost": player_cost,
             "conversion_value": player_conversion_value,
             "tick": self._tick,

--- a/environment/gym_wrapper.py
+++ b/environment/gym_wrapper.py
@@ -226,6 +226,9 @@ class AuctionNetGymEnv(gymnasium.Env):
         self._episode = 0
         self._remaining_budget = self.budget
         self._total_spend = 0.0
+        self._total_conversion_value = 0.0
+        self._total_won = 0
+        self._total_pvs = 0
         self._last_lwc = 0.0          # least winning cost from previous tick
         self._recent_xi = []          # list of (n_won, n_total) per tick for win rate
         self._current_pv_values = None
@@ -278,6 +281,9 @@ class AuctionNetGymEnv(gymnasium.Env):
         self._tick = 0
         self._remaining_budget = self.budget
         self._total_spend = 0.0
+        self._total_conversion_value = 0.0
+        self._total_won = 0
+        self._total_pvs = 0
         self._last_lwc = 0.0
         self._recent_xi = []
 
@@ -365,9 +371,12 @@ class AuctionNetGymEnv(gymnasium.Env):
             _adjust_over_cost(bids, over_cost_ratio,
                                self._bidding_env.slot_coefficients, winner_pit)
 
-        # --- update budgets ---
+        # --- update budgets and episode accumulators ---
         self._remaining_budget -= real_cost[p]
         self._total_spend += real_cost[p]
+        self._total_conversion_value += float(conversion_action_pit[p].sum())
+        self._total_won += int(xi_pit[p].sum())
+        self._total_pvs += int(xi_pit.shape[1])
         for i, agent in enumerate(self._agents):
             if agent is not None and i != p:
                 agent.remaining_budget -= real_cost[i]
@@ -375,7 +384,7 @@ class AuctionNetGymEnv(gymnasium.Env):
         # --- compute reward ---
         # Per-step: conversion value won minus optional cost penalty.
         # Terminal: optional budget utilization bonus to encourage full spend.
-        player_conversion_value = float(conversion_action_pit[p].sum())
+        player_conversion_value = float(conversion_action_pit[p].sum())  # this tick only
         player_cost = float(real_cost[p])
         reward = player_conversion_value - self.reward_lambda_cost * player_cost
 
@@ -426,6 +435,10 @@ class AuctionNetGymEnv(gymnasium.Env):
             "total_budget": self.budget,
             "remaining_budget": self._remaining_budget,
         }
+        if terminated:
+            info["budget_utilization"] = self._total_spend / self.budget
+            info["roi"] = self._total_conversion_value / max(self._total_spend, 1e-8)
+            info["win_rate"] = self._total_won / max(self._total_pvs, 1)
 
         return self._get_obs(), reward, terminated, truncated, info
 

--- a/environment/gym_wrapper.py
+++ b/environment/gym_wrapper.py
@@ -8,8 +8,8 @@ Gymnasium-compatible algorithm) can train on it directly.
 
 MDP mapping:
   - 1 Gym step  = 1 AuctionNet tick  (48 steps per episode)
-  - Action      = scalar bid multiplier α ∈ [0, max_bid_multiplier]
-  - Bids        = α × pValues  (computed internally for all PVs in the tick)
+  - Action      = scalar bid multiplier alpha, optionally plus selectivity
+  - Bids        = alpha * pValues, optionally masked to high-pValue PVs
   - Reward      = conversion_value_won - cost  (simple baseline, no λ yet)
   - Observation = 7-dim vector (see _get_obs docstring)
 
@@ -137,8 +137,9 @@ class AuctionNetGymEnv(gymnasium.Env):
 
     Each episode runs for num_ticks=48 steps. At each step the agent supplies
     a scalar bid multiplier α; the wrapper bids α × pValue for every PV
-    opportunity in that tick, runs the second-price auction against 47
-    rule-based competitors, and returns the aggregate outcome.
+    opportunity in that tick, optionally masks low-pValue opportunities, runs
+    the second-price auction against 47 rule-based competitors, and returns the
+    aggregate outcome.
 
     Observation space (7-dim Box, float32):
         [0] remaining_budget / initial_budget
@@ -149,8 +150,10 @@ class AuctionNetGymEnv(gymnasium.Env):
         [5] win rate over the last 3 ticks (0 if tick < 1)
         [6] pacing_ratio = spend_fraction / time_fraction (1.0 at tick 0)
 
-    Action space (1-dim Box, float32):
-        α ∈ [0, max_bid_multiplier]  →  bids = α × pValues
+    Action space:
+        scalar mode: 1-dim Box[-1, 1] where action[0] maps to alpha.
+        selective_topk mode: 2-dim Box[-1, 1] where action[0] maps to alpha
+        and action[1] maps to the fraction of highest-pValue PVs to bid on.
 
     Reward:
         r_t = conversion_value_won_t - cost_t
@@ -189,6 +192,14 @@ class AuctionNetGymEnv(gymnasium.Env):
         self.reward_lambda_cost = float(config.get("reward_lambda_cost", 1.0))
         self.reward_alpha_utilization = float(config.get("reward_alpha_utilization", 0.0))
         self.reward_beta_pacing = float(config.get("reward_beta_pacing", 0.0))
+        self.action_mode = str(config.get("action_mode", "scalar"))
+        if self.action_mode not in {"scalar", "selective_topk"}:
+            raise ValueError(
+                f"Unsupported action_mode={self.action_mode!r}; "
+                "expected 'scalar' or 'selective_topk'."
+            )
+        self.min_keep_fraction = float(config.get("min_keep_fraction", 0.05))
+        self.min_keep_fraction = float(np.clip(self.min_keep_fraction, 0.0, 1.0))
 
         # --- import AuctionNet modules (after path is set) ---
         from simul_bidding_env.Environment.BiddingEnv import BiddingEnv
@@ -217,9 +228,10 @@ class AuctionNetGymEnv(gymnasium.Env):
             high=np.full(7, np.inf, dtype=np.float32),
             dtype=np.float32,
         )
+        action_dim = 2 if self.action_mode == "selective_topk" else 1
         self.action_space = Box(
-            low=np.array([-1.0], dtype=np.float32),
-            high=np.array([1.0], dtype=np.float32),
+            low=np.full(action_dim, -1.0, dtype=np.float32),
+            high=np.full(action_dim, 1.0, dtype=np.float32),
             dtype=np.float32,
         )
 
@@ -315,8 +327,7 @@ class AuctionNetGymEnv(gymnasium.Env):
             truncated (bool)
             info (dict)
         """
-        action_clipped = float(np.clip(action, -1.0, 1.0))
-        alpha = ((action_clipped + 1.0) / 2.0) * self.max_bid_multiplier
+        alpha, keep_fraction = self._decode_action(action)
 
         pv_values = self._pv_gen.pv_values[self._tick]         # (n_pv, 48)
         pvalue_sigmas = self._pv_gen.pValueSigmas[self._tick]  # (n_pv, 48)
@@ -333,7 +344,11 @@ class AuctionNetGymEnv(gymnasium.Env):
         all_bids = []
         for i, agent in enumerate(self._agents):
             if i == p:
-                bids_i = alpha * pv_values[:, i]
+                player_pvalues = pv_values[:, i]
+                bids_i = alpha * player_pvalues
+                if self.action_mode == "selective_topk" and keep_fraction < 1.0:
+                    cutoff = float(np.quantile(player_pvalues, 1.0 - keep_fraction))
+                    bids_i = np.where(player_pvalues >= cutoff, bids_i, 0.0)
             elif agent is None or remaining_budgets[i] < self._bidding_env.min_remaining_budget:
                 bids_i = np.zeros(pv_values.shape[0])
             else:
@@ -437,6 +452,8 @@ class AuctionNetGymEnv(gymnasium.Env):
             "tick": self._tick,
             "total_budget": self.budget,
             "remaining_budget": self._remaining_budget,
+            "alpha": alpha,
+            "keep_fraction": keep_fraction,
         }
         if terminated:
             info["budget_utilization"] = self._total_spend / self.budget
@@ -454,6 +471,23 @@ class AuctionNetGymEnv(gymnasium.Env):
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
+
+    def _decode_action(self, action) -> tuple[float, float]:
+        """Map normalized policy action to bid alpha and PV keep fraction."""
+        action_arr = np.asarray(action, dtype=np.float32).reshape(-1)
+        alpha_signal = float(action_arr[0]) if action_arr.size else 0.0
+        alpha_signal = float(np.clip(alpha_signal, -1.0, 1.0))
+        alpha = ((alpha_signal + 1.0) / 2.0) * self.max_bid_multiplier
+
+        keep_fraction = 1.0
+        if self.action_mode == "selective_topk":
+            keep_signal = float(action_arr[1]) if action_arr.size > 1 else 1.0
+            keep_signal = float(np.clip(keep_signal, -1.0, 1.0))
+            keep_raw = (keep_signal + 1.0) / 2.0
+            keep_fraction = self.min_keep_fraction + keep_raw * (1.0 - self.min_keep_fraction)
+            keep_fraction = float(np.clip(keep_fraction, self.min_keep_fraction, 1.0))
+
+        return alpha, keep_fraction
 
     def _get_obs(self) -> np.ndarray:
         """Build the 7-dimensional observation vector.

--- a/environment/gym_wrapper.py
+++ b/environment/gym_wrapper.py
@@ -187,6 +187,7 @@ class AuctionNetGymEnv(gymnasium.Env):
         self.min_remaining_budget = float(config["min_remaining_budget"])
         self.reward_lambda_cost = float(config.get("reward_lambda_cost", 1.0))
         self.reward_alpha_utilization = float(config.get("reward_alpha_utilization", 0.0))
+        self.reward_beta_pacing = float(config.get("reward_beta_pacing", 0.0))
 
         # --- import AuctionNet modules (after path is set) ---
         from simul_bidding_env.Environment.BiddingEnv import BiddingEnv
@@ -382,11 +383,11 @@ class AuctionNetGymEnv(gymnasium.Env):
                 agent.remaining_budget -= real_cost[i]
 
         # --- compute reward ---
-        # Per-step: conversion value won minus optional cost penalty.
-        # Terminal: optional budget utilization bonus to encourage full spend.
         player_conversion_value = float(conversion_action_pit[p].sum())  # this tick only
         player_cost = float(real_cost[p])
-        reward = player_conversion_value - self.reward_lambda_cost * player_cost
+        reward = (player_conversion_value
+                  - self.reward_lambda_cost * player_cost
+                  + self.reward_beta_pacing * (player_cost / self.budget))
 
         # --- track least winning cost and win rate ---
         self._last_lwc = float(lwc_pit.mean())  # average market clearing price
@@ -415,9 +416,6 @@ class AuctionNetGymEnv(gymnasium.Env):
             or self._tick >= self.num_ticks
         )
         truncated = False
-
-        if terminated and self.reward_alpha_utilization > 0.0:
-            reward += self.reward_alpha_utilization * (self._total_spend / self.budget)
 
         # --- fetch next tick PV data for observation (if episode continues) ---
         if not terminated:

--- a/evaluation/metrics.py
+++ b/evaluation/metrics.py
@@ -95,21 +95,13 @@ def compute_budget_utilization(trajectory: List[Step]) -> float:
         trajectory (list): List of step tuples (obs, action, reward, info)
             from one full episode. Each info dict must contain:
                 - 'cost' (float): amount spent at this step
-            The first info dict (or episode metadata) must contain:
                 - 'total_budget' (float): the episode's starting budget
 
     Returns:
         utilization (float): Fraction of budget spent, in [0, 1].
     """
     total_cost = compute_total_cost(trajectory)
-
-    first_info = _extract_info(trajectory[0])
-    last_info = _extract_info(trajectory[-1])
-
-    remaining_budget_end = last_info["remaining_budget"]
-
-    # Infer initial budget
-    initial_budget = remaining_budget_end + total_cost
+    initial_budget = float(_extract_info(trajectory[0])["total_budget"])
 
     if initial_budget <= 0:
         return 0.0
@@ -131,19 +123,19 @@ def compute_win_rate(trajectory: List[Step]) -> float:
     Args:
         trajectory (list): List of step tuples (obs, action, reward, info)
             from one full episode. Each info dict must contain:
-                - 'won' (bool): True if the agent won this auction step.
+                - 'won' (int): number of auctions won this tick
+                - 'total_pvs' (int): total auction opportunities this tick
 
     Returns:
         win_rate (float): Fraction of auctions won, in [0, 1].
     """
-   
-    wins = sum(1 for step in trajectory if _extract_info(step)["won"])
-    total_steps = len(trajectory)
+    total_won = sum(_extract_info(step)["won"] for step in trajectory)
+    total_pvs = sum(_extract_info(step)["total_pvs"] for step in trajectory)
 
-    if total_steps == 0:
+    if total_pvs == 0:
         return 0.0
 
-    return wins / total_steps
+    return total_won / total_pvs
 
 
 def compute_avg_cost(trajectory: List[Step]) -> float:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ tqdm>=4.65.0
 gin-config>=0.5.0
 stable-baselines3>=2.0.0
 func-timeout>=4.3.5
+tensorboard>=2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ jupyter>=1.0.0
 scikit-learn>=1.3.0
 tqdm>=4.65.0
 gin-config>=0.5.0
-stable-baselines3>=2.0.0
+stable-baselines3>=2.3.0
 func-timeout>=4.3.5
 tensorboard>=2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pyyaml>=6.0
 jupyter>=1.0.0
 scikit-learn>=1.3.0
 tqdm>=4.65.0
+rich>=13.7.0
 gin-config>=0.5.0
 stable-baselines3>=2.3.0
 func-timeout>=4.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 gymnasium>=0.29.0
 torch>=2.0.0
-numpy>=1.24.0
+numpy>=1.25.0
 pandas>=2.0.0
 matplotlib>=3.7.0
 seaborn>=0.12.0

--- a/scripts/common_policy_eval.py
+++ b/scripts/common_policy_eval.py
@@ -1,5 +1,5 @@
 """
-Common simulator evaluator for PPO, AuctionNet IQL, and fixed-alpha policies.
+Common simulator evaluator for PPO, AuctionNet offline RL, and fixed-alpha policies.
 
 This script exists to answer the project-level question fairly:
 can PPO outperform AuctionNet's offline RL baseline under the same simulation
@@ -72,6 +72,14 @@ def parse_args() -> argparse.Namespace:
                         help="Optional PPO checkpoint base path or .zip path.")
     parser.add_argument("--episodes", type=int, default=48)
     parser.add_argument("--fixed-alphas", type=float, nargs="*", default=[])
+    parser.add_argument(
+        "--auctionnet-baselines",
+        nargs="*",
+        choices=["iql", "td3_bc"],
+        default=None,
+        help="Pretrained AuctionNet scalar-alpha baselines to evaluate. "
+             "Defaults to iql unless --skip-iql is set.",
+    )
     parser.add_argument("--skip-ppo", action="store_true")
     parser.add_argument("--skip-iql", action="store_true")
     parser.add_argument("--output-json", type=str, default=None)
@@ -174,12 +182,22 @@ class FixedAlphaPolicy(PolicyAdapter):
         return self.alpha * pv_values, {"alpha": self.alpha, "keep_fraction": 1.0}
 
 
-class IQLPolicy(PolicyAdapter):
-    def __init__(self, budget: float, cpa: float, category: int):
-        from simul_bidding_env.strategy.iql_bidding_strategy import IqlBiddingStrategy
+class AuctionNetStrategyPolicy(PolicyAdapter):
+    def __init__(self, baseline: str, budget: float, cpa: float, category: int):
+        if baseline == "iql":
+            from simul_bidding_env.strategy.iql_bidding_strategy import IqlBiddingStrategy
 
-        self.strategy = IqlBiddingStrategy(budget=budget, cpa=cpa, category=category)
-        self.name = "auctionnet_pretrained_iql"
+            strategy_cls = IqlBiddingStrategy
+            self.name = "auctionnet_pretrained_iql"
+        elif baseline == "td3_bc":
+            from simul_bidding_env.strategy.td3_bc_bidding_strategy import TD3_BCBiddingStrategy
+
+            strategy_cls = TD3_BCBiddingStrategy
+            self.name = "auctionnet_pretrained_td3_bc"
+        else:
+            raise ValueError(f"Unsupported AuctionNet baseline: {baseline}")
+
+        self.strategy = strategy_cls(budget=budget, cpa=cpa, category=category)
 
     def reset(self) -> None:
         self.strategy.reset()
@@ -197,8 +215,19 @@ class IQLPolicy(PolicyAdapter):
             history["impression"],
             history["least_winning_cost"],
         )
+        bids = np.asarray(bids, dtype=np.float64).reshape(-1)
         alpha = float(np.sum(bids) / max(np.sum(pv_values), 1e-12))
         return bids, {"alpha": alpha, "keep_fraction": 1.0}
+
+
+class IQLPolicy(AuctionNetStrategyPolicy):
+    def __init__(self, budget: float, cpa: float, category: int):
+        super().__init__("iql", budget, cpa, category)
+
+
+class TD3BCPolicy(AuctionNetStrategyPolicy):
+    def __init__(self, budget: float, cpa: float, category: int):
+        super().__init__("td3_bc", budget, cpa, category)
 
 
 class PPOPolicy(PolicyAdapter):
@@ -555,8 +584,16 @@ def main() -> None:
     policies: list[PolicyAdapter] = []
     if not args.skip_ppo:
         policies.append(PPOPolicy(env_config, agent_config, args.run_name, args.checkpoint))
-    if not args.skip_iql:
-        policies.append(IQLPolicy(
+
+    auctionnet_baselines = args.auctionnet_baselines
+    if auctionnet_baselines is None:
+        auctionnet_baselines = [] if args.skip_iql else ["iql"]
+    elif args.skip_iql:
+        auctionnet_baselines = [b for b in auctionnet_baselines if b != "iql"]
+
+    for baseline in auctionnet_baselines:
+        policies.append(AuctionNetStrategyPolicy(
+            baseline,
             budget=float(env_config["budget"]),
             cpa=float(DEFAULT_CPAS[int(env_config["player_index"])]),
             category=int(DEFAULT_CATEGORIES[int(env_config["player_index"])]),

--- a/scripts/common_policy_eval.py
+++ b/scripts/common_policy_eval.py
@@ -1,0 +1,582 @@
+"""
+Common simulator evaluator for PPO, AuctionNet IQL, and fixed-alpha policies.
+
+This script exists to answer the project-level question fairly:
+can PPO outperform AuctionNet's offline RL baseline under the same simulation
+conditions?
+
+It uses one AuctionNet simulation loop for every policy and computes metrics
+from the same raw arrays:
+  - conversions
+  - cost
+  - budget utilization
+  - aggregate CPA
+  - conversion ROI
+  - slot win rate
+  - exposure rate
+  - shared shaped reward
+
+Usage:
+    python scripts/common_policy_eval.py --config configs/gcp-run-9-selective.yaml \
+        --run-name gcp-run-9-selective --episodes 48 --fixed-alphas 50 100 130 150
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import types
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+NUM_AGENT_CATEGORY = 8
+NUM_CATEGORY = 6
+NUM_AGENTS = 48
+
+DEFAULT_BUDGETS = np.array([
+    2900, 4350, 3000, 2400, 4800, 2000, 2050, 3500,
+    4600, 2000, 2800, 2350, 2050, 2900, 4750, 3450,
+    2000, 3500, 2200, 2700, 3100, 2100, 4850, 4100,
+    2000, 4800, 3050, 4250, 2850, 2250, 2000, 3900,
+    2000, 3250, 4450, 3550, 2700, 2100, 4650, 2000,
+    3400, 2650, 2300, 4100, 4800, 4450, 2000, 2050,
+], dtype=float)
+
+DEFAULT_CPAS = np.array([
+    100, 70, 90, 110, 60, 130, 120, 80,
+    70, 130, 100, 110, 120, 90, 60, 80,
+    130, 80, 110, 100, 90, 120, 60, 70,
+    120, 60, 90, 70, 100, 110, 130, 80,
+    120, 90, 70, 80, 100, 110, 60, 130,
+    90, 100, 110, 80, 60, 70, 130, 120,
+], dtype=float)
+
+DEFAULT_CATEGORIES = np.arange(NUM_AGENTS) // NUM_AGENT_CATEGORY
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Evaluate policies in one shared AuctionNet loop.")
+    parser.add_argument("--config", type=str, default="configs/gcp-run-9-selective.yaml")
+    parser.add_argument("--run-name", type=str, default=None,
+                        help="PPO run name. If set, evaluates saved_models/ppo_<run-name>_best.")
+    parser.add_argument("--checkpoint", type=str, default=None,
+                        help="Optional PPO checkpoint base path or .zip path.")
+    parser.add_argument("--episodes", type=int, default=48)
+    parser.add_argument("--fixed-alphas", type=float, nargs="*", default=[])
+    parser.add_argument("--skip-ppo", action="store_true")
+    parser.add_argument("--skip-iql", action="store_true")
+    parser.add_argument("--output-json", type=str, default=None)
+    return parser.parse_args()
+
+
+def resolve_path(path_str: str) -> Path:
+    path = Path(path_str)
+    if not path.is_absolute():
+        path = PROJECT_ROOT / path
+    return path.resolve()
+
+
+def load_config(config_path: str) -> dict:
+    with open(resolve_path(config_path), "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def configure_paths(auctionnet_path: str) -> Path:
+    auctionnet_root = resolve_path(auctionnet_path)
+    if not auctionnet_root.exists():
+        raise FileNotFoundError(f"AuctionNet path not found: {auctionnet_root}")
+
+    for path in reversed([PROJECT_ROOT, auctionnet_root, auctionnet_root / "strategy_train_env"]):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
+
+    return auctionnet_root
+
+
+def stub_optional_model_pv_generator() -> None:
+    module_name = "simul_bidding_env.PvGenerator.ModelPvGen"
+    if module_name in sys.modules:
+        return
+
+    module = types.ModuleType(module_name)
+
+    class ModelPvGenerator:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("Common eval uses NeurIPSPvGen, not ModelPvGenerator.")
+
+    module.ModelPvGenerator = ModelPvGenerator
+    sys.modules[module_name] = module
+
+
+def get_winner(slot_pit: np.ndarray) -> np.ndarray:
+    slot_pit_t = slot_pit.T
+    num_pv = slot_pit_t.shape[0]
+    winner = np.full((num_pv, 3), -1, dtype=int)
+    for pos in range(1, 4):
+        winning = np.argwhere(slot_pit_t == pos)
+        if winning.size > 0:
+            pv_idx, agent_idx = winning.T
+            winner[pv_idx, pos - 1] = agent_idx
+    return winner
+
+
+def adjust_over_cost(bids: np.ndarray, over_cost_ratio: np.ndarray,
+                     slot_coefficients: np.ndarray, winner_pit: np.ndarray) -> None:
+    overcost_indices = np.where(over_cost_ratio > 0)[0]
+    rng = np.random.default_rng(seed=1)
+    for agent_idx in overcost_indices:
+        for slot_pos, _ in enumerate(slot_coefficients):
+            winner_indices = winner_pit[:, slot_pos]
+            pv_indices = np.where(winner_indices == agent_idx)[0]
+            num_to_drop = math.ceil(pv_indices.size * over_cost_ratio[agent_idx])
+            if num_to_drop > 0:
+                dropped = rng.choice(pv_indices, num_to_drop, replace=False)
+                bids[dropped, agent_idx] = 0
+
+
+@dataclass
+class EvalState:
+    tick: int = 0
+    remaining_budget: float = 0.0
+    total_spend: float = 0.0
+    last_lwc: float = 0.0
+    recent_xi: list[tuple[int, int]] = field(default_factory=list)
+
+
+class PolicyAdapter:
+    name: str
+
+    def reset(self) -> None:
+        pass
+
+    def bid(self, tick: int, pv_values: np.ndarray, pvalue_sigmas: np.ndarray,
+            history: dict[str, list], eval_state: EvalState) -> tuple[np.ndarray, dict[str, float]]:
+        raise NotImplementedError
+
+
+class FixedAlphaPolicy(PolicyAdapter):
+    def __init__(self, alpha: float):
+        self.alpha = float(alpha)
+        self.name = f"fixed_alpha_{self.alpha:g}"
+
+    def bid(self, tick: int, pv_values: np.ndarray, pvalue_sigmas: np.ndarray,
+            history: dict[str, list], eval_state: EvalState) -> tuple[np.ndarray, dict[str, float]]:
+        return self.alpha * pv_values, {"alpha": self.alpha, "keep_fraction": 1.0}
+
+
+class IQLPolicy(PolicyAdapter):
+    def __init__(self, budget: float, cpa: float, category: int):
+        from simul_bidding_env.strategy.iql_bidding_strategy import IqlBiddingStrategy
+
+        self.strategy = IqlBiddingStrategy(budget=budget, cpa=cpa, category=category)
+        self.name = "auctionnet_pretrained_iql"
+
+    def reset(self) -> None:
+        self.strategy.reset()
+
+    def bid(self, tick: int, pv_values: np.ndarray, pvalue_sigmas: np.ndarray,
+            history: dict[str, list], eval_state: EvalState) -> tuple[np.ndarray, dict[str, float]]:
+        self.strategy.remaining_budget = eval_state.remaining_budget
+        bids = self.strategy.bidding(
+            tick,
+            pv_values,
+            pvalue_sigmas,
+            history["pvalue_info"],
+            history["bids"],
+            history["auction"],
+            history["impression"],
+            history["least_winning_cost"],
+        )
+        alpha = float(np.sum(bids) / max(np.sum(pv_values), 1e-12))
+        return bids, {"alpha": alpha, "keep_fraction": 1.0}
+
+
+class PPOPolicy(PolicyAdapter):
+    def __init__(self, env_config: dict, agent_config: dict, run_name: str | None,
+                 checkpoint: str | None):
+        from stable_baselines3.common.monitor import Monitor
+        from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
+
+        from agents.ppo_agent import PPOAgent
+        from environment.gym_wrapper import AuctionNetGymEnv
+
+        if checkpoint is None:
+            if run_name is None:
+                raise ValueError("PPO evaluation requires --run-name or --checkpoint")
+            model_path = PROJECT_ROOT / "saved_models" / f"ppo_{run_name}_best" / "best_model"
+        else:
+            model_path = resolve_path(checkpoint)
+            if model_path.suffix == ".zip":
+                model_path = model_path.with_suffix("")
+
+        if not model_path.with_suffix(".zip").exists():
+            raise FileNotFoundError(f"PPO checkpoint not found: {model_path}.zip")
+
+        vec_env = DummyVecEnv([lambda: Monitor(AuctionNetGymEnv(env_config))])
+        vecnorm_path = model_path.with_name("best_model_vecnormalize.pkl")
+        if not vecnorm_path.exists():
+            fallback = Path(str(model_path) + "_vecnormalize.pkl")
+            vecnorm_path = fallback if fallback.exists() else vecnorm_path
+        if vecnorm_path.exists():
+            vec_env = VecNormalize.load(str(vecnorm_path), vec_env)
+            vec_env.training = False
+            vec_env.norm_reward = False
+            print(f"Loaded PPO VecNormalize stats: {vecnorm_path}")
+        else:
+            print(f"WARNING: no PPO VecNormalize stats found near {model_path}")
+
+        self.agent = PPOAgent(
+            observation_space=vec_env.observation_space,
+            action_space=vec_env.action_space,
+            config=agent_config,
+            env=vec_env,
+        )
+        self.agent.load(str(model_path), env=vec_env)
+        self.env = vec_env
+        self.max_bid_multiplier = float(env_config["max_bid_multiplier"])
+        self.action_mode = str(env_config.get("action_mode", "scalar"))
+        self.min_keep_fraction = float(env_config.get("min_keep_fraction", 0.05))
+        self.num_ticks = int(env_config["num_ticks"])
+        self.initial_budget = float(env_config["budget"])
+        self.name = f"ppo_{run_name or model_path.name}"
+
+    def _obs(self, tick: int, player_pvalues: np.ndarray, eval_state: EvalState) -> np.ndarray:
+        budget_frac = eval_state.remaining_budget / self.initial_budget
+        time_frac = tick / self.num_ticks
+        mean_pval = float(player_pvalues.mean())
+        std_pval = float(player_pvalues.std())
+        norm_price = eval_state.last_lwc / self.initial_budget
+        if eval_state.recent_xi:
+            total_won = sum(w for w, _ in eval_state.recent_xi)
+            total_pv = sum(t for _, t in eval_state.recent_xi)
+            win_rate = total_won / total_pv if total_pv > 0 else 0.0
+        else:
+            win_rate = 0.0
+        spend_frac = eval_state.total_spend / self.initial_budget
+        pacing_ratio = spend_frac / time_frac if time_frac > 0 else 1.0
+        return np.array(
+            [budget_frac, time_frac, mean_pval, std_pval, norm_price, win_rate, pacing_ratio],
+            dtype=np.float32,
+        )
+
+    def _decode_action(self, action: np.ndarray) -> tuple[float, float]:
+        action_arr = np.asarray(action, dtype=np.float32).reshape(-1)
+        alpha_signal = float(np.clip(action_arr[0], -1.0, 1.0))
+        alpha = ((alpha_signal + 1.0) / 2.0) * self.max_bid_multiplier
+        keep_fraction = 1.0
+        if self.action_mode == "selective_topk":
+            keep_signal = float(np.clip(action_arr[1], -1.0, 1.0)) if action_arr.size > 1 else 1.0
+            keep_raw = (keep_signal + 1.0) / 2.0
+            keep_fraction = self.min_keep_fraction + keep_raw * (1.0 - self.min_keep_fraction)
+            keep_fraction = float(np.clip(keep_fraction, self.min_keep_fraction, 1.0))
+        return float(alpha), keep_fraction
+
+    def bid(self, tick: int, pv_values: np.ndarray, pvalue_sigmas: np.ndarray,
+            history: dict[str, list], eval_state: EvalState) -> tuple[np.ndarray, dict[str, float]]:
+        obs = self._obs(tick, pv_values, eval_state)
+        policy_obs = self.env.normalize_obs(obs)
+        action, _, _ = self.agent.select_action(policy_obs, deterministic=True)
+        alpha, keep_fraction = self._decode_action(action)
+        bids = alpha * pv_values
+        if self.action_mode == "selective_topk" and keep_fraction < 1.0:
+            cutoff = float(np.quantile(pv_values, 1.0 - keep_fraction))
+            bids = np.where(pv_values >= cutoff, bids, 0.0)
+        return bids, {"alpha": alpha, "keep_fraction": keep_fraction}
+
+
+def build_competitors(player_index: int):
+    from simul_bidding_env.strategy.pid_bidding_strategy import PidBiddingStrategy
+
+    agents = []
+    for i in range(NUM_AGENTS):
+        if i == player_index:
+            agents.append(None)
+            continue
+        agent = PidBiddingStrategy(exp_tempral_ratio=np.ones(48))
+        agent.budget = float(DEFAULT_BUDGETS[i])
+        agent.cpa = float(DEFAULT_CPAS[i])
+        agent.category = int(DEFAULT_CATEGORIES[i])
+        agent.name = f"agent_{i}"
+        agents.append(agent)
+    return agents
+
+
+def shaped_reward(env_config: dict, conversion_value: float, cost: float,
+                  total_spend: float, tick: int) -> float:
+    reward_value_scale = float(env_config.get("reward_value_scale", 1.0))
+    reward_lambda_cost = float(env_config.get("reward_lambda_cost", 1.0))
+    reward_beta_pacing = float(env_config.get("reward_beta_pacing", 0.0))
+    budget = float(env_config["budget"])
+    num_ticks = int(env_config["num_ticks"])
+    time_frac = (tick + 1) / num_ticks
+    pacing_ratio = (total_spend / budget) / time_frac
+    return (
+        reward_value_scale * conversion_value
+        - reward_lambda_cost * cost
+        + reward_beta_pacing * min(pacing_ratio, 1.0)
+    )
+
+
+def evaluate_policy(policy: PolicyAdapter, env_config: dict, episodes: int) -> dict[str, Any]:
+    from simul_bidding_env.Environment.BiddingEnv import BiddingEnv
+    from simul_bidding_env.PvGenerator.NeurIPSPvGen import NeurIPSPvGen
+
+    player_index = int(env_config["player_index"])
+    player_budget = float(env_config["budget"])
+    num_ticks = int(env_config["num_ticks"])
+    num_episode = int(env_config.get("num_episode", episodes))
+    pv_num = int(env_config["pv_num"])
+    min_remaining_budget = float(env_config["min_remaining_budget"])
+
+    env = BiddingEnv(min_remaining_budget=min_remaining_budget)
+    competitors = build_competitors(player_index)
+
+    totals = {
+        "conversions": 0.0,
+        "cost": 0.0,
+        "slot_wins": 0,
+        "exposures": 0,
+        "auctions": 0,
+        "shaped_rewards": [],
+        "alphas": [],
+        "keep_fractions": [],
+    }
+
+    for ep in range(episodes):
+        episode_id = ep % num_episode
+        env.reset(episode=episode_id)
+        pv_gen = NeurIPSPvGen(
+            episode=episode_id,
+            num_tick=num_ticks,
+            num_agent=NUM_AGENTS,
+            num_agent_category=NUM_AGENT_CATEGORY,
+            num_category=NUM_CATEGORY,
+            pv_num=pv_num,
+        )
+
+        policy.reset()
+        for i, agent in enumerate(competitors):
+            if agent is None:
+                continue
+            agent.reset()
+            agent.remaining_budget = float(DEFAULT_BUDGETS[i])
+
+        eval_state = EvalState(remaining_budget=player_budget)
+        history_all = {
+            "pvalue_info": [],
+            "bids": [],
+            "auction": [],
+            "impression": [],
+            "least_winning_cost": [],
+        }
+        ep_reward = 0.0
+
+        for tick in range(num_ticks):
+            pv_values = pv_gen.pv_values[tick]
+            pvalue_sigmas = pv_gen.pValueSigmas[tick]
+            remaining_budgets = np.array([
+                eval_state.remaining_budget if i == player_index else (
+                    agent.remaining_budget if agent is not None else 0.0
+                )
+                for i, agent in enumerate(competitors)
+            ])
+
+            all_bids = []
+            for i, agent in enumerate(competitors):
+                if i == player_index:
+                    player_history = {
+                        "pvalue_info": [x[i] for x in history_all["pvalue_info"]],
+                        "bids": [x[i] for x in history_all["bids"]],
+                        "auction": [x[i] for x in history_all["auction"]],
+                        "impression": [x[i] for x in history_all["impression"]],
+                        "least_winning_cost": history_all["least_winning_cost"],
+                    }
+                    bids_i, action_info = policy.bid(
+                        tick,
+                        pv_values[:, i],
+                        pvalue_sigmas[:, i],
+                        player_history,
+                        eval_state,
+                    )
+                    totals["alphas"].append(float(action_info["alpha"]))
+                    totals["keep_fractions"].append(float(action_info["keep_fraction"]))
+                elif agent is None or remaining_budgets[i] < min_remaining_budget:
+                    bids_i = np.zeros(pv_values.shape[0])
+                else:
+                    bids_i = agent.bidding(
+                        tick,
+                        pv_values[:, i],
+                        pvalue_sigmas[:, i],
+                        [x[i] for x in history_all["pvalue_info"]],
+                        [x[i] for x in history_all["bids"]],
+                        [x[i] for x in history_all["auction"]],
+                        [x[i] for x in history_all["impression"]],
+                        history_all["least_winning_cost"],
+                    )
+                all_bids.append(np.asarray(bids_i, dtype=np.float64))
+
+            bids = np.array(all_bids).T
+            bids = np.clip(bids, 0, None)
+
+            winner_pit = None
+            while True:
+                xi_pit, slot_pit, cost_pit, is_exposed_pit, conversion_action_pit, \
+                    lwc_pit, market_price_pit = env.simulate_ad_bidding(
+                        pv_values, pvalue_sigmas, bids
+                    )
+                real_cost = (cost_pit * is_exposed_pit).sum(axis=1)
+                over_cost_ratio = np.maximum(
+                    (real_cost - remaining_budgets) / (real_cost + 1e-4), 0
+                )
+                winner_pit = get_winner(slot_pit)
+                if over_cost_ratio.max() == 0:
+                    break
+                adjust_over_cost(bids, over_cost_ratio, env.slot_coefficients, winner_pit)
+
+            player_cost = float(real_cost[player_index])
+            player_conversions = float(conversion_action_pit[player_index].sum())
+            player_slot_wins = int(xi_pit[player_index].sum())
+            player_exposures = int(is_exposed_pit[player_index].sum())
+            player_auctions = int(xi_pit.shape[1])
+
+            eval_state.remaining_budget -= player_cost
+            eval_state.total_spend += player_cost
+            eval_state.last_lwc = float(lwc_pit.mean())
+            eval_state.tick = tick + 1
+            eval_state.recent_xi.append((player_slot_wins, player_auctions))
+            if len(eval_state.recent_xi) > 3:
+                eval_state.recent_xi.pop(0)
+
+            for i, agent in enumerate(competitors):
+                if agent is not None and i != player_index:
+                    agent.remaining_budget -= real_cost[i]
+
+            totals["conversions"] += player_conversions
+            totals["cost"] += player_cost
+            totals["slot_wins"] += player_slot_wins
+            totals["exposures"] += player_exposures
+            totals["auctions"] += player_auctions
+            ep_reward += shaped_reward(
+                env_config, player_conversions, player_cost, eval_state.total_spend, tick
+            )
+
+            pvalue_info = np.stack((pv_values.T, pvalue_sigmas.T), axis=-1)
+            history_all["pvalue_info"].append(pvalue_info)
+            history_all["bids"].append(bids.T)
+            auction_info = np.stack((xi_pit, slot_pit, cost_pit), axis=-1)
+            history_all["auction"].append(auction_info)
+            impression_info = np.stack((is_exposed_pit, conversion_action_pit), axis=-1)
+            history_all["impression"].append(impression_info)
+            history_all["least_winning_cost"].append(lwc_pit)
+
+            if eval_state.remaining_budget < min_remaining_budget:
+                break
+
+        totals["shaped_rewards"].append(ep_reward)
+
+    conversions = totals["conversions"]
+    cost = totals["cost"]
+    auctions = totals["auctions"]
+    shaped_rewards = np.array(totals["shaped_rewards"], dtype=float)
+    alphas = np.array(totals["alphas"], dtype=float)
+    keep_fractions = np.array(totals["keep_fractions"], dtype=float)
+
+    return {
+        "policy": policy.name,
+        "episodes": episodes,
+        "conversions": conversions,
+        "cost": cost,
+        "budget_utilization": cost / (episodes * player_budget),
+        "aggregate_cpa": cost / conversions if conversions > 0 else None,
+        "conversion_roi": conversions / cost if cost > 0 else 0.0,
+        "slot_win_rate": totals["slot_wins"] / auctions if auctions > 0 else 0.0,
+        "exposure_rate": totals["exposures"] / auctions if auctions > 0 else 0.0,
+        "shaped_ep_reward_mean": float(shaped_rewards.mean()) if shaped_rewards.size else 0.0,
+        "shaped_ep_reward_std": float(shaped_rewards.std(ddof=1)) if shaped_rewards.size > 1 else 0.0,
+        "alpha_mean": float(alphas.mean()) if alphas.size else 0.0,
+        "alpha_std": float(alphas.std(ddof=1)) if alphas.size > 1 else 0.0,
+        "keep_fraction_mean": float(keep_fractions.mean()) if keep_fractions.size else 1.0,
+        "keep_fraction_std": float(keep_fractions.std(ddof=1)) if keep_fractions.size > 1 else 0.0,
+    }
+
+
+def print_result(result: dict[str, Any]) -> None:
+    print(f"\n=== {result['policy']} ===")
+    print(f"episodes:            {result['episodes']}")
+    print(f"conversions:         {result['conversions']:.6f}")
+    print(f"cost:                {result['cost']:.6f}")
+    print(f"budget utilization:  {result['budget_utilization']:.2%}")
+    cpa = result["aggregate_cpa"]
+    print(f"aggregate CPA:       {cpa:.6f}" if cpa is not None else "aggregate CPA:       n/a")
+    print(f"conversion ROI:      {result['conversion_roi']:.6f}")
+    print(f"slot win rate:       {result['slot_win_rate']:.2%}")
+    print(f"exposure rate:       {result['exposure_rate']:.2%}")
+    print(
+        "shaped ep reward:    "
+        f"{result['shaped_ep_reward_mean']:.2f} +/- {result['shaped_ep_reward_std']:.2f}"
+    )
+    print(f"alpha mean/std:      {result['alpha_mean']:.2f} / {result['alpha_std']:.2f}")
+    print(
+        "keep frac mean/std:  "
+        f"{result['keep_fraction_mean']:.3f} / {result['keep_fraction_std']:.3f}"
+    )
+
+
+def json_default(obj):
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_config(args.config)
+    env_config = config["environment"]
+    agent_config = config.get("agent", {})
+
+    auctionnet_root = configure_paths(env_config["auctionnet_path"])
+    os.chdir(auctionnet_root)
+    stub_optional_model_pv_generator()
+
+    policies: list[PolicyAdapter] = []
+    if not args.skip_ppo:
+        policies.append(PPOPolicy(env_config, agent_config, args.run_name, args.checkpoint))
+    if not args.skip_iql:
+        policies.append(IQLPolicy(
+            budget=float(env_config["budget"]),
+            cpa=float(DEFAULT_CPAS[int(env_config["player_index"])]),
+            category=int(DEFAULT_CATEGORIES[int(env_config["player_index"])]),
+        ))
+    for alpha in args.fixed_alphas:
+        policies.append(FixedAlphaPolicy(alpha))
+
+    results = []
+    for policy in policies:
+        result = evaluate_policy(policy, env_config, args.episodes)
+        results.append(result)
+        print_result(result)
+
+    if args.output_json:
+        output_path = resolve_path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2, default=json_default)
+        print(f"\nWrote metrics JSON: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate_auctionnet_iql.py
+++ b/scripts/evaluate_auctionnet_iql.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import os
 import sys
+import types
 from pathlib import Path
 
 import gin
@@ -77,8 +78,34 @@ def require_iql_assets(auctionnet_root: Path) -> None:
         )
 
 
+def stub_optional_model_pv_generator() -> None:
+    """Avoid importing AuctionNet's optional model-PV stack for NeurIPS PV eval.
+
+    AuctionNet's Controller imports ModelPvGenerator at module import time even
+    when the configured generator is "neuripsPvGen". That optional path pulls in
+    extra dependencies such as einops. This baseline only uses NeurIPSPvGen, so
+    provide a small placeholder module to keep the import lightweight.
+    """
+    module_name = "simul_bidding_env.PvGenerator.ModelPvGen"
+    if module_name in sys.modules:
+        return
+
+    module = types.ModuleType(module_name)
+
+    class ModelPvGenerator:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError(
+                "ModelPvGenerator is not available in this lightweight IQL eval. "
+                "Use Controller.pv_generator_type='neuripsPvGen'."
+            )
+
+    module.ModelPvGenerator = ModelPvGenerator
+    sys.modules[module_name] = module
+
+
 def patch_auctionnet_for_project_env(env_config: dict) -> None:
     """Patch AuctionNet's controller to match this project's comparison setup."""
+    stub_optional_model_pv_generator()
     from simul_bidding_env.Controller.Controller import Controller
     from simul_bidding_env.strategy.pid_bidding_strategy import PidBiddingStrategy
 
@@ -109,6 +136,7 @@ def patch_auctionnet_for_project_env(env_config: dict) -> None:
 
 
 def run_iql_eval(env_config: dict, episodes: int) -> dict:
+    stub_optional_model_pv_generator()
     from simul_bidding_env.strategy.iql_bidding_strategy import IqlBiddingStrategy
     import run.run_test as auctionnet_run_test
 

--- a/scripts/evaluate_auctionnet_iql.py
+++ b/scripts/evaluate_auctionnet_iql.py
@@ -1,0 +1,212 @@
+"""
+Evaluate AuctionNet's pretrained IQL strategy under this project's config.
+
+This is a system-level baseline for comparing our PPO policy against the
+official AuctionNet offline RL agent. It intentionally uses AuctionNet's
+pretrained IQL model and 16-dimensional engineered state, while matching the
+important environment knobs from the selected PPO config: player index, budget,
+PV count, and number of ticks.
+
+Usage:
+    python scripts/evaluate_auctionnet_iql.py --config configs/gcp-run-9-selective.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+import gin
+import numpy as np
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate pretrained AuctionNet IQL with this project's env config."
+    )
+    parser.add_argument("--config", type=str, default="configs/gcp-run-9-selective.yaml")
+    parser.add_argument("--episodes", type=int, default=None)
+    parser.add_argument("--output-json", type=str, default=None)
+    return parser.parse_args()
+
+
+def resolve_path(path_str: str) -> Path:
+    path = Path(path_str)
+    if not path.is_absolute():
+        path = PROJECT_ROOT / path
+    return path.resolve()
+
+
+def load_config(config_path: str) -> dict:
+    with open(resolve_path(config_path), "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def configure_paths(auctionnet_path: str) -> Path:
+    auctionnet_root = resolve_path(auctionnet_path)
+    if not auctionnet_root.exists():
+        raise FileNotFoundError(f"AuctionNet path not found: {auctionnet_root}")
+
+    paths = [
+        PROJECT_ROOT,
+        auctionnet_root,
+        auctionnet_root / "strategy_train_env",
+    ]
+    for path in reversed(paths):
+        path_str = str(path)
+        if path_str not in sys.path:
+            sys.path.insert(0, path_str)
+
+    return auctionnet_root
+
+
+def require_iql_assets(auctionnet_root: Path) -> None:
+    iql_dir = auctionnet_root / "simul_bidding_env" / "strategy" / "official_agent" / "IQLtest"
+    required = [iql_dir / "iql_model.pth", iql_dir / "normalize_dict.pkl"]
+    missing = [str(path) for path in required if not path.exists()]
+    if missing:
+        raise FileNotFoundError(
+            "Missing pretrained AuctionNet IQL asset(s):\n" + "\n".join(missing)
+        )
+
+
+def patch_auctionnet_for_project_env(env_config: dict) -> None:
+    """Patch AuctionNet's controller to match this project's comparison setup."""
+    from simul_bidding_env.Controller.Controller import Controller
+    from simul_bidding_env.strategy.pid_bidding_strategy import PidBiddingStrategy
+
+    player_index = int(env_config["player_index"])
+    player_budget = float(env_config["budget"])
+    num_ticks = int(env_config["num_ticks"])
+
+    def initialize_pid_agents(self):
+        return [
+            PidBiddingStrategy(exp_tempral_ratio=np.ones(num_ticks))
+            for _ in range(self.num_agent)
+        ]
+
+    def calculate_budget_with_project_player(self):
+        budgets = np.array([
+            2900, 4350, 3000, 2400, 4800, 2000, 2050, 3500,
+            4600, 2000, 2800, 2350, 2050, 2900, 4750, 3450,
+            2000, 3500, 2200, 2700, 3100, 2100, 4850, 4100,
+            2000, 4800, 3050, 4250, 2850, 2250, 2000, 3900,
+            2000, 3250, 4450, 3550, 2700, 2100, 4650, 2000,
+            3400, 2650, 2300, 4100, 4800, 4450, 2000, 2050,
+        ], dtype=float)
+        budgets[player_index] = player_budget
+        return budgets.tolist()
+
+    Controller.initialize_agents = initialize_pid_agents
+    Controller.calculate_budget = calculate_budget_with_project_player
+
+
+def run_iql_eval(env_config: dict, episodes: int) -> dict:
+    from simul_bidding_env.strategy.iql_bidding_strategy import IqlBiddingStrategy
+    import run.run_test as auctionnet_run_test
+
+    patch_auctionnet_for_project_env(env_config)
+
+    player_budget = float(env_config["budget"])
+    player_index = int(env_config["player_index"])
+    num_ticks = int(env_config["num_ticks"])
+    pv_num = int(env_config["pv_num"])
+
+    # The official IQL strategy is a scalar alpha policy trained by AuctionNet.
+    # Player 0 has CPA 100/category 0 in this project's PPO experiments.
+    auctionnet_run_test.initialize_player_agent = lambda: IqlBiddingStrategy(
+        budget=player_budget,
+        cpa=100,
+        category=0,
+    )
+
+    gin.clear_config()
+    gin.bind_parameter("Controller.num_agent_category", 8)
+    gin.bind_parameter("Controller.num_category", 6)
+    gin.bind_parameter("Controller.num_tick", num_ticks)
+    gin.bind_parameter("Controller.pv_num", pv_num)
+
+    result = auctionnet_run_test.run_test(
+        generate_log=False,
+        num_episode=episodes,
+        num_tick=num_ticks,
+        player_index=player_index,
+    )
+
+    total_value = float(result["reward"])
+    total_cost = float(result["allCost"])
+    budget_utilization = float(result["budget_consumer_ratio"])
+    win_rate = float(result["win_pv_ratio"])
+
+    return {
+        "policy": "auctionnet_pretrained_iql",
+        "episodes": episodes,
+        "player_index": player_index,
+        "budget": player_budget,
+        "pv_num": pv_num,
+        "num_ticks": num_ticks,
+        "total_value": total_value,
+        "total_cost": total_cost,
+        "roi": total_value / total_cost if total_cost > 0 else 0.0,
+        "budget_utilization": budget_utilization,
+        "win_rate": win_rate,
+        "cpa": float(result["cpa"]),
+        "cpa_constraint": float(result["cpaConstraint"]),
+        "score": float(result["score"]),
+        "raw_result": result,
+    }
+
+
+def print_metrics(metrics: dict) -> None:
+    print("\n=== AuctionNet Pretrained IQL Baseline ===")
+    print(f"episodes:            {metrics['episodes']}")
+    print(f"player_index:        {metrics['player_index']}")
+    print(f"budget:              {metrics['budget']:.2f}")
+    print(f"pv_num:              {metrics['pv_num']}")
+    print(f"total value:         {metrics['total_value']:.6f}")
+    print(f"total cost:          {metrics['total_cost']:.6f}")
+    print(f"ROI value/cost:      {metrics['roi']:.6f}")
+    print(f"budget utilization:  {metrics['budget_utilization']:.2%}")
+    print(f"win/exposure rate:   {metrics['win_rate']:.2%}")
+    print(f"CPA:                 {metrics['cpa']:.6f}")
+    print(f"CPA constraint:      {metrics['cpa_constraint']:.6f}")
+    print(f"score:               {metrics['score']:.6f}")
+    print("\nNote: AuctionNet IQL is a scalar-alpha policy, so it does not use")
+    print("gcp-run-9's selective_topk second action dimension.")
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_config(args.config)
+    env_config = config["environment"]
+
+    auctionnet_root = configure_paths(env_config["auctionnet_path"])
+    require_iql_assets(auctionnet_root)
+
+    # AuctionNet imports and relative model paths assume its repo root as cwd.
+    os.chdir(auctionnet_root)
+
+    episodes = args.episodes
+    if episodes is None:
+        episodes = int(env_config.get("num_episode", 48))
+
+    metrics = run_iql_eval(env_config, episodes)
+    print_metrics(metrics)
+
+    if args.output_json:
+        output_path = resolve_path(args.output_json)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(metrics, f, indent=2)
+        print(f"\nWrote metrics JSON: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate_auctionnet_iql.py
+++ b/scripts/evaluate_auctionnet_iql.py
@@ -172,6 +172,7 @@ def run_iql_eval(env_config: dict, episodes: int) -> dict:
     total_cost = float(result["allCost"])
     budget_utilization = float(result["budget_consumer_ratio"])
     win_rate = float(result["win_pv_ratio"])
+    aggregate_cpa = total_cost / total_value if total_value > 0 else 0.0
 
     return {
         "policy": "auctionnet_pretrained_iql",
@@ -185,7 +186,8 @@ def run_iql_eval(env_config: dict, episodes: int) -> dict:
         "roi": total_value / total_cost if total_cost > 0 else 0.0,
         "budget_utilization": budget_utilization,
         "win_rate": win_rate,
-        "cpa": float(result["cpa"]),
+        "aggregate_cpa": aggregate_cpa,
+        "mean_episode_cpa": float(result["cpa"]),
         "cpa_constraint": float(result["cpaConstraint"]),
         "score": float(result["score"]),
         "raw_result": result,
@@ -203,11 +205,22 @@ def print_metrics(metrics: dict) -> None:
     print(f"ROI value/cost:      {metrics['roi']:.6f}")
     print(f"budget utilization:  {metrics['budget_utilization']:.2%}")
     print(f"win/exposure rate:   {metrics['win_rate']:.2%}")
-    print(f"CPA:                 {metrics['cpa']:.6f}")
+    print(f"aggregate CPA:       {metrics['aggregate_cpa']:.6f}")
+    print(f"mean episode CPA:    {metrics['mean_episode_cpa']:.6f}")
     print(f"CPA constraint:      {metrics['cpa_constraint']:.6f}")
     print(f"score:               {metrics['score']:.6f}")
     print("\nNote: AuctionNet IQL is a scalar-alpha policy, so it does not use")
     print("gcp-run-9's selective_topk second action dimension.")
+
+
+def json_default(obj):
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        return float(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
 
 
 def main() -> None:
@@ -232,7 +245,7 @@ def main() -> None:
         output_path = resolve_path(args.output_json)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with open(output_path, "w", encoding="utf-8") as f:
-            json.dump(metrics, f, indent=2)
+            json.dump(metrics, f, indent=2, default=json_default)
         print(f"\nWrote metrics JSON: {output_path}")
 
 

--- a/scripts/hpc_train.sh
+++ b/scripts/hpc_train.sh
@@ -22,6 +22,7 @@
 #   source /scratch/zh2312/miniforge3/etc/profile.d/conda.sh
 #   conda create -n rl-ad-bidding python=3.9.12 -y
 #   conda activate rl-ad-bidding
+#   git clone https://github.com/alimama-tech/AuctionNet.git /scratch/zh2312/AuctionNet
 #   cd /scratch/zh2312/rl-ad-bidding && git pull && pip install -r requirements.txt
 #
 # Usage:

--- a/scripts/hpc_train.sh
+++ b/scripts/hpc_train.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #SBATCH --job-name=rl-ad-bidding
 #SBATCH --account=torch_pr_932_general
-#SBATCH --partition=cpu_short
+#SBATCH --partition=cs
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=8
-#SBATCH --mem=32GB
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=32G
 #SBATCH --time=12:00:00
 #SBATCH --output=logs/%j_%x.out
 #SBATCH --error=logs/%j_%x.err

--- a/scripts/hpc_train.sh
+++ b/scripts/hpc_train.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #SBATCH --job-name=rl-ad-bidding
-#SBATCH --partition=gpu
+#SBATCH --account=TODO_run_sacctmgr_show_associations_user=zh2312
+#SBATCH --partition=c12m85-a100-1
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=8
@@ -10,41 +11,43 @@
 #SBATCH --output=logs/%j_%x.out
 #SBATCH --error=logs/%j_%x.err
 #SBATCH --mail-type=BEGIN,END,FAIL
-#SBATCH --mail-user=YOUR_NETID@nyu.edu
+#SBATCH --mail-user=zh2312@nyu.edu
 
 # ---------------------------------------------------------------
-# NYU Greene HPC — Training job for rl-ad-bidding
-# Usage: sbatch scripts/hpc_train.sh [--config configs/default.yaml]
+# NYU Torch HPC — Training job for rl-ad-bidding
+#
+# One-time setup required before first run — see README or ask Eric:
+#   /scratch/zh2312/rl-ad-bidding/overlay-15GB-500K.ext3  (overlay with conda env)
+#   /share/apps/images/cuda12.3.2-cudnn9.0.0-ubuntu-22.04.4.sif  (Singularity image)
+#
+# Usage:
+#   sbatch scripts/hpc_train.sh
+#   sbatch scripts/hpc_train.sh configs/my_experiment.yaml
 # ---------------------------------------------------------------
 
 set -euo pipefail
 
-echo "Job ID:       $SLURM_JOB_ID"
-echo "Node:         $SLURMD_NODENAME"
-echo "Started at:   $(date)"
+echo "Job ID:     $SLURM_JOB_ID"
+echo "Node:       $SLURMD_NODENAME"
+echo "Started at: $(date)"
 
-# --- Environment setup ---
-module purge
-module load anaconda3/2023.09
-
-conda activate rl-ad-bidding  # replace with your actual env name
-
-# Verify GPU is visible
-nvidia-smi
-
-# --- Working directory ---
-cd $SLURM_SUBMIT_DIR
-
-# --- Config (override via sbatch --export or positional arg) ---
 CONFIG=${1:-configs/default.yaml}
-echo "Using config: $CONFIG"
+echo "Config:     $CONFIG"
 
-# --- Create log directory if it doesn't exist ---
 mkdir -p logs saved_models
 
-# --- Launch training ---
-python scripts/train.py \
-    --config "$CONFIG" \
-    --run-name "slurm_${SLURM_JOB_ID}"
+OVERLAY=/scratch/zh2312/rl-ad-bidding/overlay-15GB-500K.ext3
+SIF=/share/apps/images/cuda12.3.2-cudnn9.0.0-ubuntu-22.04.4.sif
+WORKDIR=/scratch/zh2312/rl-ad-bidding
+
+singularity exec --bind /scratch --nv \
+  --overlay ${OVERLAY}:ro \
+  ${SIF} \
+  /bin/bash -c "
+    source /ext3/env.sh
+    conda activate rl-ad-bidding
+    cd ${WORKDIR}
+    python scripts/train.py --config ${CONFIG} --run-name slurm_\${SLURM_JOB_ID}
+  "
 
 echo "Finished at: $(date)"

--- a/scripts/hpc_train.sh
+++ b/scripts/hpc_train.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 #SBATCH --job-name=rl-ad-bidding
 #SBATCH --account=torch_pr_932_general
-#SBATCH --partition=c12m85-a100-1
+#SBATCH --partition=cpu_short
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=8
 #SBATCH --mem=32GB
 #SBATCH --time=12:00:00
-#SBATCH --gres=gpu:a100:1
 #SBATCH --output=logs/%j_%x.out
 #SBATCH --error=logs/%j_%x.err
 #SBATCH --mail-type=BEGIN,END,FAIL
@@ -40,7 +39,7 @@ OVERLAY=/scratch/zh2312/rl-ad-bidding/overlay-15GB-500K.ext3
 SIF=/share/apps/images/cuda12.3.2-cudnn9.0.0-ubuntu-22.04.4.sif
 WORKDIR=/scratch/zh2312/rl-ad-bidding
 
-singularity exec --bind /scratch --nv \
+singularity exec --bind /scratch \
   --overlay ${OVERLAY}:ro \
   ${SIF} \
   /bin/bash -c "

--- a/scripts/hpc_train.sh
+++ b/scripts/hpc_train.sh
@@ -15,9 +15,14 @@
 # ---------------------------------------------------------------
 # NYU Torch HPC — Training job for rl-ad-bidding
 #
-# One-time setup required before first run — see README or ask Eric:
-#   /scratch/zh2312/rl-ad-bidding/overlay-15GB-500K.ext3  (overlay with conda env)
-#   /share/apps/images/cuda12.3.2-cudnn9.0.0-ubuntu-22.04.4.sif  (Singularity image)
+# One-time setup (run once on login node, no Singularity needed):
+#   cd /scratch/zh2312
+#   wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+#   sh Miniforge3-Linux-x86_64.sh -b -p /scratch/zh2312/miniforge3
+#   source /scratch/zh2312/miniforge3/etc/profile.d/conda.sh
+#   conda create -n rl-ad-bidding python=3.9.12 -y
+#   conda activate rl-ad-bidding
+#   cd /scratch/zh2312/rl-ad-bidding && pip install -r requirements.txt
 #
 # Usage:
 #   sbatch scripts/hpc_train.sh
@@ -26,6 +31,8 @@
 
 set -euo pipefail
 
+REPO=/scratch/zh2312/rl-ad-bidding
+
 echo "Job ID:     $SLURM_JOB_ID"
 echo "Node:       $SLURMD_NODENAME"
 echo "Started at: $(date)"
@@ -33,20 +40,12 @@ echo "Started at: $(date)"
 CONFIG=${1:-configs/default.yaml}
 echo "Config:     $CONFIG"
 
-mkdir -p logs saved_models
+mkdir -p $REPO/logs $REPO/saved_models
 
-OVERLAY=/scratch/zh2312/rl-ad-bidding/overlay-15GB-500K.ext3
-SIF=/share/apps/images/cuda12.3.2-cudnn9.0.0-ubuntu-22.04.4.sif
-WORKDIR=/scratch/zh2312/rl-ad-bidding
+source /scratch/zh2312/miniforge3/etc/profile.d/conda.sh
+conda activate rl-ad-bidding
 
-singularity exec --bind /scratch \
-  --overlay ${OVERLAY}:ro \
-  ${SIF} \
-  /bin/bash -c "
-    source /ext3/env.sh
-    conda activate rl-ad-bidding
-    cd ${WORKDIR}
-    python scripts/train.py --config ${CONFIG} --run-name slurm_\${SLURM_JOB_ID}
-  "
+cd $REPO
+python scripts/train.py --config ${CONFIG} --run-name slurm_${SLURM_JOB_ID}
 
 echo "Finished at: $(date)"

--- a/scripts/hpc_train.sh
+++ b/scripts/hpc_train.sh
@@ -22,7 +22,7 @@
 #   source /scratch/zh2312/miniforge3/etc/profile.d/conda.sh
 #   conda create -n rl-ad-bidding python=3.9.12 -y
 #   conda activate rl-ad-bidding
-#   cd /scratch/zh2312/rl-ad-bidding && pip install -r requirements.txt
+#   cd /scratch/zh2312/rl-ad-bidding && git pull && pip install -r requirements.txt
 #
 # Usage:
 #   sbatch scripts/hpc_train.sh

--- a/scripts/hpc_train.sh
+++ b/scripts/hpc_train.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=rl-ad-bidding
-#SBATCH --account=TODO_run_sacctmgr_show_associations_user=zh2312
+#SBATCH --account=torch_pr_932_general
 #SBATCH --partition=c12m85-a100-1
 #SBATCH --nodes=1
 #SBATCH --ntasks=1

--- a/scripts/quick_eval.py
+++ b/scripts/quick_eval.py
@@ -1,11 +1,16 @@
 """
-Quick evaluation of a saved PPO checkpoint.
-Usage: python scripts/quick_eval.py --run-name gcp-run-3 [--n-episodes 10]
+Quick evaluation of a saved PPO checkpoint, or a fixed-alpha baseline.
+
+Usage:
+    python scripts/quick_eval.py --run-name gcp-run-3 [--n-episodes 10]
+    python scripts/quick_eval.py --config configs/gcp-run-5.yaml --alpha-override 100
 """
 import argparse
+import statistics
 import sys
 from pathlib import Path
 
+import numpy as np
 import yaml
 from stable_baselines3.common.monitor import Monitor  # needed for vec_env
 from stable_baselines3.common.vec_env import DummyVecEnv
@@ -20,10 +25,57 @@ from environment.gym_wrapper import AuctionNetGymEnv
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--run-name", type=str, required=True)
+    parser.add_argument("--run-name", type=str, default=None,
+                        help="Saved checkpoint name (required unless --alpha-override is set)")
     parser.add_argument("--config", type=str, default="configs/default.yaml")
     parser.add_argument("--n-episodes", type=int, default=10)
+    parser.add_argument("--alpha-override", type=float, default=None,
+                        help="If set, bypass the policy and emit this constant alpha "
+                             "(in [0, max_bid_multiplier]) every step. Used for "
+                             "fixed-bid baseline diagnostics.")
     return parser.parse_args()
+
+
+def _alpha_to_action(alpha: float, max_bid_multiplier: float) -> np.ndarray:
+    """Invert the env's action→alpha rescaling: alpha = ((a+1)/2) * max_bid_multiplier."""
+    a = (alpha / max_bid_multiplier) * 2.0 - 1.0
+    return np.array([a], dtype=np.float32)
+
+
+def evaluate_fixed_alpha(env: AuctionNetGymEnv, alpha: float, n_episodes: int) -> dict:
+    """Roll out n_episodes with a constant alpha. Returns same keys as PPOAgent.evaluate
+    plus ep_rew_mean (computed from the env's own reward signal).
+    """
+    if not 0 <= alpha <= env.max_bid_multiplier:
+        raise ValueError(f"alpha {alpha} outside [0, {env.max_bid_multiplier}]")
+    action = _alpha_to_action(alpha, env.max_bid_multiplier)
+
+    total_conversion_value = 0.0
+    total_cost = 0.0
+    total_won = 0
+    total_auctions = 0
+    ep_rewards = []
+
+    for _ in range(n_episodes):
+        obs, _ = env.reset()
+        terminated = truncated = False
+        ep_rew = 0.0
+        while not (terminated or truncated):
+            obs, reward, terminated, truncated, info = env.step(action)
+            ep_rew += reward
+            total_conversion_value += info["conversion_value"]
+            total_cost += info["cost"]
+            total_won += info["won"]
+            total_auctions += info.get("total_pvs", env._pv_gen.pv_values[0].shape[0])
+        ep_rewards.append(ep_rew)
+
+    return {
+        "roi": total_conversion_value / total_cost if total_cost > 0 else 0.0,
+        "budget_utilization": total_cost / (n_episodes * env.budget),
+        "win_rate": total_won / total_auctions if total_auctions > 0 else 0.0,
+        "ep_rew_mean": statistics.mean(ep_rewards),
+        "ep_rew_std": statistics.stdev(ep_rewards) if len(ep_rewards) > 1 else 0.0,
+    }
 
 
 def main():
@@ -35,6 +87,24 @@ def main():
 
     env_config = config["environment"]
     agent_config = config.get("agent", {})
+
+    if args.alpha_override is not None:
+        raw_env = AuctionNetGymEnv(env_config)
+        print(f"Fixed-alpha baseline: α={args.alpha_override}, "
+              f"{args.n_episodes} episodes, reward = "
+              f"{env_config.get('reward_value_scale', 1.0)}*v "
+              f"- {env_config.get('reward_lambda_cost', 1.0)}*c "
+              f"+ {env_config.get('reward_beta_pacing', 0.0)}*min(pacing,1)")
+        metrics = evaluate_fixed_alpha(raw_env, args.alpha_override, args.n_episodes)
+        print(f"  ROI:                {metrics['roi']:.4f}")
+        print(f"  Budget utilization: {metrics['budget_utilization']:.2%}")
+        print(f"  Win rate:           {metrics['win_rate']:.2%}")
+        print(f"  ep_rew_mean:        {metrics['ep_rew_mean']:.2f} ± {metrics['ep_rew_std']:.2f}")
+        return
+
+    if args.run_name is None:
+        print("Either --run-name or --alpha-override is required")
+        sys.exit(1)
 
     model_path = PROJECT_ROOT / "saved_models" / f"ppo_{args.run_name}_best" / "best_model"
     if not model_path.with_suffix(".zip").exists():

--- a/scripts/quick_eval.py
+++ b/scripts/quick_eval.py
@@ -1,0 +1,61 @@
+"""
+Quick evaluation of a saved PPO checkpoint.
+Usage: python scripts/quick_eval.py --run-name gcp-run-3 [--n-episodes 10]
+"""
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+from stable_baselines3.common.monitor import Monitor
+from stable_baselines3.common.vec_env import DummyVecEnv
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from agents.ppo_agent import PPOAgent
+from environment.gym_wrapper import AuctionNetGymEnv
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-name", type=str, required=True)
+    parser.add_argument("--config", type=str, default="configs/default.yaml")
+    parser.add_argument("--n-episodes", type=int, default=10)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    config_path = PROJECT_ROOT / args.config
+    with open(config_path) as f:
+        config = yaml.safe_load(f)
+
+    env_config = config["environment"]
+    agent_config = config.get("agent", {})
+
+    model_path = PROJECT_ROOT / "saved_models" / f"ppo_{args.run_name}_best" / "best_model"
+    if not model_path.with_suffix(".zip").exists():
+        print(f"No checkpoint found at {model_path}.zip")
+        sys.exit(1)
+
+    eval_env = DummyVecEnv([lambda: Monitor(AuctionNetGymEnv(env_config))])
+    agent = PPOAgent(
+        observation_space=eval_env.observation_space,
+        action_space=eval_env.action_space,
+        config=agent_config,
+        env=eval_env,
+    )
+    agent.load(str(model_path), env=eval_env)
+
+    print(f"Evaluating {args.run_name} over {args.n_episodes} episodes...")
+    metrics = agent.evaluate(eval_env, n_episodes=args.n_episodes)
+    print(f"  ROI:                {metrics['roi']:.4f}")
+    print(f"  Budget utilization: {metrics['budget_utilization']:.2%}")
+    print(f"  Win rate:           {metrics['win_rate']:.2%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/quick_eval.py
+++ b/scripts/quick_eval.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 import yaml
-from stable_baselines3.common.monitor import Monitor
+from stable_baselines3.common.monitor import Monitor  # needed for vec_env
 from stable_baselines3.common.vec_env import DummyVecEnv
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -41,17 +41,19 @@ def main():
         print(f"No checkpoint found at {model_path}.zip")
         sys.exit(1)
 
-    eval_env = DummyVecEnv([lambda: Monitor(AuctionNetGymEnv(env_config))])
+    vec_env = DummyVecEnv([lambda: Monitor(AuctionNetGymEnv(env_config))])
+    raw_env = AuctionNetGymEnv(env_config)
+
     agent = PPOAgent(
-        observation_space=eval_env.observation_space,
-        action_space=eval_env.action_space,
+        observation_space=vec_env.observation_space,
+        action_space=vec_env.action_space,
         config=agent_config,
-        env=eval_env,
+        env=vec_env,
     )
-    agent.load(str(model_path), env=eval_env)
+    agent.load(str(model_path), env=vec_env)
 
     print(f"Evaluating {args.run_name} over {args.n_episodes} episodes...")
-    metrics = agent.evaluate(eval_env, n_episodes=args.n_episodes)
+    metrics = agent.evaluate(raw_env, n_eval_episodes=args.n_episodes)
     print(f"  ROI:                {metrics['roi']:.4f}")
     print(f"  Budget utilization: {metrics['budget_utilization']:.2%}")
     print(f"  Win rate:           {metrics['win_rate']:.2%}")

--- a/scripts/quick_eval.py
+++ b/scripts/quick_eval.py
@@ -36,10 +36,12 @@ def parse_args():
     return parser.parse_args()
 
 
-def _alpha_to_action(alpha: float, max_bid_multiplier: float) -> np.ndarray:
+def _alpha_to_action(alpha: float, max_bid_multiplier: float, action_shape=(1,)) -> np.ndarray:
     """Invert the env's action→alpha rescaling: alpha = ((a+1)/2) * max_bid_multiplier."""
     a = (alpha / max_bid_multiplier) * 2.0 - 1.0
-    return np.array([a], dtype=np.float32)
+    action = np.ones(action_shape, dtype=np.float32)
+    action.flat[0] = a
+    return action
 
 
 def evaluate_fixed_alpha(env: AuctionNetGymEnv, alpha: float, n_episodes: int) -> dict:
@@ -48,7 +50,7 @@ def evaluate_fixed_alpha(env: AuctionNetGymEnv, alpha: float, n_episodes: int) -
     """
     if not 0 <= alpha <= env.max_bid_multiplier:
         raise ValueError(f"alpha {alpha} outside [0, {env.max_bid_multiplier}]")
-    action = _alpha_to_action(alpha, env.max_bid_multiplier)
+    action = _alpha_to_action(alpha, env.max_bid_multiplier, env.action_space.shape)
 
     total_conversion_value = 0.0
     total_cost = 0.0

--- a/scripts/quick_eval.py
+++ b/scripts/quick_eval.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import numpy as np
 import yaml
 from stable_baselines3.common.monitor import Monitor  # needed for vec_env
-from stable_baselines3.common.vec_env import DummyVecEnv
+from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -112,6 +112,15 @@ def main():
         sys.exit(1)
 
     vec_env = DummyVecEnv([lambda: Monitor(AuctionNetGymEnv(env_config))])
+    vecnorm_path = model_path.with_name("best_model_vecnormalize.pkl")
+    if vecnorm_path.exists():
+        vec_env = VecNormalize.load(str(vecnorm_path), vec_env)
+        vec_env.training = False
+        vec_env.norm_reward = False
+        print(f"Loaded VecNormalize stats: {vecnorm_path}")
+    elif config.get("training", {}).get("norm_reward", False):
+        print(f"WARNING: expected VecNormalize stats but did not find {vecnorm_path}")
+
     raw_env = AuctionNetGymEnv(env_config)
 
     agent = PPOAgent(
@@ -127,6 +136,7 @@ def main():
     print(f"  ROI:                {metrics['roi']:.4f}")
     print(f"  Budget utilization: {metrics['budget_utilization']:.2%}")
     print(f"  Win rate:           {metrics['win_rate']:.2%}")
+    print(f"  ep_rew_mean:        {metrics['ep_rew_mean']:.2f} ± {metrics['ep_rew_std']:.2f}")
 
 
 if __name__ == "__main__":

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import yaml
 from stable_baselines3.common.callbacks import (
+    BaseCallback,
     CheckpointCallback,
     EvalCallback,
     StopTrainingOnNoModelImprovement,
@@ -37,6 +38,21 @@ def load_config(config_path: str) -> dict:
 
 
 _MONITOR_KEYWORDS = ("budget_utilization", "roi", "win_rate")
+
+
+class EpisodeMetricsCallback(BaseCallback):
+    """Forward per-episode custom metrics from Monitor to the SB3 logger (→ W&B)."""
+
+    def _on_step(self) -> bool:
+        for info in self.locals["infos"]:
+            ep = info.get("episode")
+            if ep is None:
+                continue
+            for key in _MONITOR_KEYWORDS:
+                if key in ep:
+                    self.logger.record(f"rollout/{key}", ep[key])
+        return True
+
 
 def make_env(env_config: dict):
     def _init():
@@ -140,7 +156,7 @@ def main():
     print(f"W&B:             {use_wandb}")
     print("=" * 60)
 
-    callbacks = [checkpoint_cb, eval_cb]
+    callbacks = [checkpoint_cb, eval_cb, EpisodeMetricsCallback()]
     if wandb_callback is not None:
         callbacks.append(wandb_callback)
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -4,9 +4,13 @@ import sys
 from pathlib import Path
 
 import yaml
-from stable_baselines3.common.callbacks import CheckpointCallback, EvalCallback
+from stable_baselines3.common.callbacks import (
+    CheckpointCallback,
+    EvalCallback,
+    StopTrainingOnNoModelImprovement,
+)
 from stable_baselines3.common.monitor import Monitor
-from stable_baselines3.common.vec_env import DummyVecEnv
+from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -68,7 +72,8 @@ def main():
         )
 
     # --- Environments ---
-    vec_env = DummyVecEnv([make_env(env_config)])
+    n_envs = int(training_config.get("n_envs", 8))
+    vec_env = SubprocVecEnv([make_env(env_config) for _ in range(n_envs)])
     eval_env = DummyVecEnv([make_env(env_config)])
 
     # --- Agent ---
@@ -87,10 +92,17 @@ def main():
         env=vec_env,
     )
 
+    # --- Warm-start: resume from best checkpoint if available ---
+    best_model_path = PROJECT_ROOT / "saved_models" / f"ppo_{run_name}_best" / "best_model.zip"
+    if best_model_path.exists():
+        print(f"Resuming from checkpoint: {best_model_path}")
+        agent.load(str(best_model_path), env=vec_env)
+
     # --- Callbacks ---
     num_ticks = int(env_config.get("num_ticks", 48))
     save_interval = int(training_config.get("save_interval", 500))
     eval_interval = int(training_config.get("eval_interval", 100))
+    early_stop_patience = int(training_config.get("early_stop_patience", 10))
 
     checkpoint_cb = CheckpointCallback(
         save_freq=max(save_interval * num_ticks, 1),
@@ -100,10 +112,18 @@ def main():
         save_vecnormalize=False,
     )
 
+    early_stop_cb = StopTrainingOnNoModelImprovement(
+        max_no_improvement_evals=early_stop_patience,
+        min_evals=early_stop_patience,
+        verbose=1,
+    )
+
     eval_cb = EvalCallback(
         eval_env,
+        best_model_save_path=str(PROJECT_ROOT / "saved_models" / f"ppo_{run_name}_best"),
         eval_freq=max(eval_interval * num_ticks, 1),
         n_eval_episodes=5,
+        callback_after_eval=early_stop_cb,
         deterministic=True,
         verbose=1,
     )

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -6,12 +6,13 @@ from pathlib import Path
 import yaml
 from stable_baselines3.common.callbacks import (
     BaseCallback,
+    CallbackList,
     CheckpointCallback,
     EvalCallback,
     StopTrainingOnNoModelImprovement,
 )
 from stable_baselines3.common.monitor import Monitor
-from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
+from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv, VecNormalize
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
@@ -38,6 +39,30 @@ def load_config(config_path: str) -> dict:
 
 
 _MONITOR_KEYWORDS = ("budget_utilization", "roi", "win_rate")
+
+
+class BestModelVecNormalizeCallback(BaseCallback):
+    """Saves VecNormalize running stats alongside best_model.zip after every eval.
+
+    EvalCallback calls model.save() directly and never writes the VecNormalize
+    sidecar. Without this callback, warm-starts and post-hoc evaluation load the
+    policy into a fresh (mean=0, std=1) normalizer — observations look completely
+    different from training and the policy behaves unpredictably.
+
+    Runs as callback_after_eval so it fires at eval frequency (~200 times over 2M
+    steps), not on every environment step. Stats are written after every eval;
+    if no new best was found, the file is simply overwritten with the current
+    running stats, which are within one eval interval of the true best-model stats.
+    """
+
+    def __init__(self, vec_env: VecNormalize, save_path: str):
+        super().__init__()
+        self._vec_env = vec_env
+        self._save_path = save_path
+
+    def _on_step(self) -> bool:
+        self._vec_env.save(os.path.join(self._save_path, "best_model_vecnormalize.pkl"))
+        return True
 
 
 class EpisodeMetricsCallback(BaseCallback):
@@ -101,6 +126,17 @@ def main():
     vec_env = SubprocVecEnv([make_env(env_config) for _ in range(n_envs)])
     eval_env = DummyVecEnv([make_env(env_config)])
 
+    # Reward normalization: stabilises the value function by keeping targets
+    # at unit variance regardless of raw reward scale. Controlled per-config so
+    # old runs can be reproduced without normalization.
+    norm_reward = bool(training_config.get("norm_reward", False))
+    if norm_reward:
+        vec_env = VecNormalize(vec_env, norm_obs=True, norm_reward=True, clip_obs=10.0)
+        # eval env: keep obs normalisation in sync but never normalise rewards —
+        # EvalCallback reports mean reward in original units so comparisons stay valid.
+        eval_env = VecNormalize(eval_env, norm_obs=True, norm_reward=False,
+                                training=False, clip_obs=10.0)
+
     # --- Agent ---
     agent_config_train = {
         **agent_config,
@@ -119,6 +155,12 @@ def main():
     if best_model_path.exists():
         print(f"Resuming from checkpoint: {best_model_path}")
         agent.load(str(best_model_path), env=vec_env)
+        if norm_reward and isinstance(agent.env, VecNormalize):
+            # load() sets training=False/norm_reward=False for inference; flip back
+            # to training mode so running stats keep updating and rewards stay normalised.
+            agent.env.training = True
+            agent.env.norm_reward = True
+            vec_env = agent.env  # keep outer reference in sync with the loaded wrapper
 
     # --- Callbacks ---
     num_ticks = int(env_config.get("num_ticks", 48))
@@ -131,7 +173,7 @@ def main():
         save_path=str(PROJECT_ROOT / "saved_models"),
         name_prefix=f"ppo_{run_name}",
         save_replay_buffer=False,
-        save_vecnormalize=False,
+        save_vecnormalize=norm_reward,
     )
 
     early_stop_cb = StopTrainingOnNoModelImprovement(
@@ -140,12 +182,23 @@ def main():
         verbose=1,
     )
 
+    best_model_dir = str(PROJECT_ROOT / "saved_models" / f"ppo_{run_name}_best")
+    if norm_reward:
+        # Chain: early stopping + VecNormalize sidecar save on every eval.
+        after_eval_cb = CallbackList([
+            early_stop_cb,
+            BestModelVecNormalizeCallback(vec_env, best_model_dir),
+        ])
+    else:
+        after_eval_cb = early_stop_cb
+
+    n_eval_episodes = int(training_config.get("n_eval_episodes", 5))
     eval_cb = EvalCallback(
         eval_env,
-        best_model_save_path=str(PROJECT_ROOT / "saved_models" / f"ppo_{run_name}_best"),
+        best_model_save_path=best_model_dir,
         eval_freq=max(eval_interval * num_ticks, 1),
-        n_eval_episodes=5,
-        callback_after_eval=early_stop_cb,
+        n_eval_episodes=n_eval_episodes,
+        callback_after_eval=after_eval_cb,
         deterministic=True,
         verbose=1,
     )

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -36,9 +36,11 @@ def load_config(config_path: str) -> dict:
         return yaml.safe_load(f)
 
 
+_MONITOR_KEYWORDS = ("budget_utilization", "roi", "win_rate")
+
 def make_env(env_config: dict):
     def _init():
-        return Monitor(AuctionNetGymEnv(env_config))
+        return Monitor(AuctionNetGymEnv(env_config), info_keywords=_MONITOR_KEYWORDS)
     return _init
 
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -78,11 +78,8 @@ def main():
     eval_env = DummyVecEnv([make_env(env_config)])
 
     # --- Agent ---
-    # squash_output: maps Gaussian output through tanh+rescale so actions always
-    # land in [0, max_bid_multiplier] on init, instead of half being clipped to 0.
     agent_config_train = {
         **agent_config,
-        "policy_kwargs": {"squash_output": True},
         "tensorboard_log": str(PROJECT_ROOT / "logs"),
     }
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -62,14 +62,20 @@ def main():
 
     # --- W&B (optional — controlled by logging.use_wandb in config) ---
     use_wandb = logging_config.get("use_wandb", False)
+    wandb_callback = None
     if use_wandb:
         import wandb
+        from wandb.integration.sb3 import WandbCallback
         wandb.init(
             project=logging_config.get("project_name", "rl-ad-bidding"),
             entity=logging_config.get("entity", None),
             name=run_name,
             config={**env_config, **agent_config, "total_timesteps": total_timesteps},
-            sync_tensorboard=True,  # streams SB3's TensorBoard logs into W&B
+            sync_tensorboard=True,
+        )
+        wandb_callback = WandbCallback(
+            gradient_save_freq=0,
+            verbose=0,
         )
 
     # --- Environments ---
@@ -132,9 +138,13 @@ def main():
     print(f"W&B:             {use_wandb}")
     print("=" * 60)
 
+    callbacks = [checkpoint_cb, eval_cb]
+    if wandb_callback is not None:
+        callbacks.append(wandb_callback)
+
     agent.update(
         total_timesteps=total_timesteps,
-        callback=[checkpoint_cb, eval_cb],
+        callback=callbacks,
         progress_bar=True,
     )
 

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -66,6 +66,7 @@ def main():
         import wandb
         wandb.init(
             project=logging_config.get("project_name", "rl-ad-bidding"),
+            entity=logging_config.get("entity", None),
             name=run_name,
             config={**env_config, **agent_config, "total_timesteps": total_timesteps},
             sync_tensorboard=True,  # streams SB3's TensorBoard logs into W&B

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -4,12 +4,10 @@ import sys
 from pathlib import Path
 
 import yaml
-from stable_baselines3.common.callbacks import CheckpointCallback
+from stable_baselines3.common.callbacks import CheckpointCallback, EvalCallback
 from stable_baselines3.common.monitor import Monitor
 from stable_baselines3.common.vec_env import DummyVecEnv
 
-# Ensure project root is importable when running:
-# python scripts/train.py
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
@@ -20,24 +18,9 @@ from agents.ppo_agent import PPOAgent
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Train PPO on AuctionNetGymEnv")
-    parser.add_argument(
-        "--config",
-        type=str,
-        default="configs/default_local.yaml",
-        help="Path to YAML config file",
-    )
-    parser.add_argument(
-        "--run-name",
-        type=str,
-        default=None,
-        help="Optional run name override",
-    )
-    parser.add_argument(
-        "--total-timesteps",
-        type=int,
-        default=None,
-        help="Optional override for total training timesteps",
-    )
+    parser.add_argument("--config", type=str, default="configs/default.yaml")
+    parser.add_argument("--run-name", type=str, default=None)
+    parser.add_argument("--total-timesteps", type=int, default=None)
     return parser.parse_args()
 
 
@@ -45,35 +28,14 @@ def load_config(config_path: str) -> dict:
     path = Path(config_path)
     if not path.is_absolute():
         path = PROJECT_ROOT / path
-    path = path.resolve()
-
-    print(f"Loading config from: {path}")
-
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path.resolve(), "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
 
 def make_env(env_config: dict):
     def _init():
-        env = AuctionNetGymEnv(env_config)
-        env = Monitor(env)
-        return env
+        return Monitor(AuctionNetGymEnv(env_config))
     return _init
-
-
-def infer_total_timesteps(config: dict, cli_total_timesteps: int | None) -> int:
-    if cli_total_timesteps is not None:
-        return cli_total_timesteps
-
-    training_cfg = config.get("training", {})
-    env_cfg = config.get("environment", {})
-
-    if "total_timesteps" in training_cfg:
-        return int(training_cfg["total_timesteps"])
-
-    n_episodes = int(training_cfg.get("n_episodes", 1000))
-    num_ticks = int(env_cfg.get("num_ticks", 48))
-    return n_episodes * num_ticks
 
 
 def main():
@@ -86,50 +48,85 @@ def main():
     logging_config = config.get("logging", {})
 
     run_name = args.run_name or logging_config.get("run_name", "baseline")
-    total_timesteps = infer_total_timesteps(config, args.total_timesteps)
+
+    total_timesteps = args.total_timesteps
+    if total_timesteps is None:
+        total_timesteps = int(agent_config.get("total_timesteps", 500_000))
 
     os.makedirs(PROJECT_ROOT / "saved_models", exist_ok=True)
     os.makedirs(PROJECT_ROOT / "logs", exist_ok=True)
 
+    # --- W&B (optional — controlled by logging.use_wandb in config) ---
+    use_wandb = logging_config.get("use_wandb", False)
+    if use_wandb:
+        import wandb
+        wandb.init(
+            project=logging_config.get("project_name", "rl-ad-bidding"),
+            name=run_name,
+            config={**env_config, **agent_config, "total_timesteps": total_timesteps},
+            sync_tensorboard=True,  # streams SB3's TensorBoard logs into W&B
+        )
+
+    # --- Environments ---
     vec_env = DummyVecEnv([make_env(env_config)])
+    eval_env = DummyVecEnv([make_env(env_config)])
+
+    # --- Agent ---
+    # squash_output: maps Gaussian output through tanh+rescale so actions always
+    # land in [0, max_bid_multiplier] on init, instead of half being clipped to 0.
+    agent_config_train = {
+        **agent_config,
+        "policy_kwargs": {"squash_output": True},
+        "tensorboard_log": str(PROJECT_ROOT / "logs"),
+    }
 
     agent = PPOAgent(
         observation_space=vec_env.observation_space,
         action_space=vec_env.action_space,
-        config=agent_config,
+        config=agent_config_train,
         env=vec_env,
     )
 
-    save_interval = int(training_config.get("save_interval", 500))
+    # --- Callbacks ---
     num_ticks = int(env_config.get("num_ticks", 48))
-    save_freq_steps = max(save_interval * num_ticks, 1)
+    save_interval = int(training_config.get("save_interval", 500))
+    eval_interval = int(training_config.get("eval_interval", 100))
 
-    checkpoint_callback = CheckpointCallback(
-        save_freq=save_freq_steps,
+    checkpoint_cb = CheckpointCallback(
+        save_freq=max(save_interval * num_ticks, 1),
         save_path=str(PROJECT_ROOT / "saved_models"),
         name_prefix=f"ppo_{run_name}",
         save_replay_buffer=False,
         save_vecnormalize=False,
     )
 
+    eval_cb = EvalCallback(
+        eval_env,
+        eval_freq=max(eval_interval * num_ticks, 1),
+        n_eval_episodes=5,
+        deterministic=True,
+        verbose=1,
+    )
+
     print("=" * 60)
-    print(f"Config:           {args.config}")
-    print(f"Run name:         {run_name}")
-    print(f"Total timesteps:  {total_timesteps}")
-    print(f"Save every:       {save_freq_steps} env steps")
+    print(f"Run name:        {run_name}")
+    print(f"Total timesteps: {total_timesteps:,}")
+    print(f"W&B:             {use_wandb}")
     print("=" * 60)
 
-    metrics = agent.update(
+    agent.update(
         total_timesteps=total_timesteps,
-        callback=checkpoint_callback,
+        callback=[checkpoint_cb, eval_cb],
         progress_bar=True,
     )
 
     final_path = PROJECT_ROOT / "saved_models" / f"ppo_{run_name}_final"
     agent.save(str(final_path))
+    print(f"Model saved to: {final_path}.zip")
 
-    print(f"Training complete. Metrics: {metrics}")
-    print(f"Final model saved to: {final_path}.zip")
+    if use_wandb:
+        import wandb
+        wandb.finish()
 
 
 if __name__ == "__main__":

--- a/test_agent.py
+++ b/test_agent.py
@@ -1,0 +1,232 @@
+"""
+Smoke test for PPOAgent.
+Run from project root: conda run -n rl-ad-bidding python test_agent.py
+
+Validates the agent in isolation — no train.py needed. Covers:
+  1. Initialization with a plain env
+  2. select_action() output shape and dtype
+  3. Short training run (one full rollout buffer + gradient update)
+  4. save() / load() round-trip
+  5. evaluate() returns correct RTB metrics
+  6. VecNormalize save/load round-trip
+"""
+
+import shutil
+import sys
+
+
+def step(msg):
+    print(f"  [ ] {msg}", end="", flush=True)
+
+def ok():
+    print("\r  [x]", flush=True)
+
+def fail(e):
+    print(f"\r  [!] FAILED — {e}")
+    sys.exit(1)
+
+
+print("=" * 55)
+print("  PPOAgent Smoke Test")
+print("=" * 55)
+
+# ── 1. Config ────────────────────────────────────────────
+print("\n[1] Loading config")
+try:
+    step("Reading configs/default.yaml")
+    import yaml
+    with open("configs/default.yaml") as f:
+        full_cfg = yaml.safe_load(f)
+    env_cfg = full_cfg["environment"].copy()
+    agent_cfg = full_cfg["agent"].copy()
+    # Small pv_num so each tick runs fast
+    env_cfg["pv_num"] = 1000
+    # One rollout buffer = n_steps steps. With a single env that means 384 steps
+    # = 8 complete 48-tick episodes. Use 400 to guarantee at least one update.
+    agent_cfg["total_timesteps"] = 400
+    ok()
+    print(f"      n_steps={agent_cfg.get('n_steps', 384)}, "
+          f"total_timesteps={agent_cfg['total_timesteps']} (smoke test override)")
+except Exception as e:
+    fail(e)
+
+# ── 2. Imports ───────────────────────────────────────────
+print("\n[2] Importing modules")
+try:
+    step("AuctionNetGymEnv")
+    from environment.gym_wrapper import AuctionNetGymEnv
+    ok()
+
+    step("PPOAgent")
+    from agents.ppo_agent import PPOAgent
+    ok()
+
+    step("SB3 VecEnv utilities")
+    from stable_baselines3.common.vec_env import DummyVecEnv, VecNormalize
+    ok()
+except Exception as e:
+    fail(e)
+
+# ── 3. Init ──────────────────────────────────────────────
+print("\n[3] Initialising PPOAgent with plain env")
+try:
+    step("Building DummyVecEnv")
+    vec_env = DummyVecEnv([lambda: AuctionNetGymEnv(env_cfg)])
+    ok()
+
+    step("Instantiating PPOAgent")
+    agent = PPOAgent(
+        vec_env.observation_space,
+        vec_env.action_space,
+        agent_cfg,
+        env=vec_env,
+    )
+    ok()
+
+    step("Checking n_steps == 384")
+    assert agent.model.n_steps == agent_cfg.get("n_steps", 384), \
+        f"expected 384, got {agent.model.n_steps}"
+    ok()
+
+    step("Checking ent_coef == 0.01")
+    assert abs(agent.model.ent_coef - agent_cfg.get("ent_coef", 0.01)) < 1e-6, \
+        f"expected 0.01, got {agent.model.ent_coef}"
+    ok()
+except Exception as e:
+    fail(e)
+
+# ── 4. select_action() ───────────────────────────────────
+print("\n[4] Testing select_action()")
+try:
+    import numpy as np
+
+    step("Reset env, get first obs")
+    obs = vec_env.reset()
+    ok()
+
+    step("select_action(obs, deterministic=False) — stochastic")
+    action, lp, val = agent.select_action(obs, deterministic=False)
+    assert action.shape == (1, 1), f"expected (1,1), got {action.shape}"
+    assert action.dtype in (np.float32, np.float64), f"unexpected dtype {action.dtype}"
+    assert lp is None and val is None
+    ok()
+    print(f"      action = {action.flatten()[0]:.4f}  (in [0, {env_cfg['max_bid_multiplier']}])")
+
+    step("select_action(obs, deterministic=True) — greedy")
+    action_det, _, _ = agent.select_action(obs, deterministic=True)
+    assert action_det.shape == (1, 1)
+    ok()
+except Exception as e:
+    fail(e)
+
+# ── 5. Short training run ────────────────────────────────
+print("\n[5] Short training run (one rollout buffer + gradient update)")
+try:
+    step(f"agent.update(total_timesteps={agent_cfg['total_timesteps']})")
+    metrics = agent.update(total_timesteps=agent_cfg["total_timesteps"])
+    assert metrics["trained_timesteps"] == agent_cfg["total_timesteps"]
+    ok()
+    print(f"      trained_timesteps = {metrics['trained_timesteps']}")
+except Exception as e:
+    fail(e)
+
+# ── 6. save() / load() round-trip (plain env) ────────────
+print("\n[6] save() / load() round-trip — plain env")
+_SAVE_PATH = "saved_models/_smoke_test_plain"
+try:
+    step("save()")
+    agent.save(_SAVE_PATH)
+    from pathlib import Path
+    assert Path(_SAVE_PATH + ".zip").exists(), "model .zip not found"
+    assert not Path(_SAVE_PATH + "_vecnormalize.pkl").exists(), \
+        "unexpected vecnorm sidecar for plain env"
+    ok()
+
+    step("load() and re-attach env")
+    agent2 = PPOAgent(
+        vec_env.observation_space,
+        vec_env.action_space,
+        agent_cfg,
+    )
+    agent2.load(_SAVE_PATH, env=vec_env)
+    assert agent2.model is not None
+    ok()
+
+    step("select_action() after load")
+    obs = vec_env.reset()
+    action_loaded, _, _ = agent2.select_action(obs, deterministic=True)
+    assert action_loaded.shape == (1, 1)
+    ok()
+except Exception as e:
+    fail(e)
+
+# ── 7. VecNormalize save/load round-trip ─────────────────
+print("\n[7] save() / load() round-trip — VecNormalize env")
+_SAVE_PATH_VN = "saved_models/_smoke_test_vecnorm"
+try:
+    step("Build VecNormalize-wrapped env")
+    raw_env = DummyVecEnv([lambda: AuctionNetGymEnv(env_cfg)])
+    norm_env = VecNormalize(raw_env, norm_obs=True, norm_reward=True)
+    ok()
+
+    step("Train briefly to accumulate normalizer stats")
+    agent_vn = PPOAgent(
+        norm_env.observation_space,
+        norm_env.action_space,
+        agent_cfg,
+        env=norm_env,
+    )
+    agent_vn.update(total_timesteps=agent_cfg["total_timesteps"])
+    ok()
+
+    step("save() — expect model .zip + vecnormalize .pkl")
+    agent_vn.save(_SAVE_PATH_VN)
+    assert Path(_SAVE_PATH_VN + ".zip").exists(), "model .zip not found"
+    assert Path(_SAVE_PATH_VN + "_vecnormalize.pkl").exists(), \
+        "vecnormalize .pkl not found"
+    ok()
+
+    step("load() — stats restored into fresh VecNormalize env")
+    fresh_raw = DummyVecEnv([lambda: AuctionNetGymEnv(env_cfg)])
+    fresh_norm = VecNormalize(fresh_raw, norm_obs=True, norm_reward=True)
+    agent_vn2 = PPOAgent(
+        fresh_norm.observation_space,
+        fresh_norm.action_space,
+        agent_cfg,
+    )
+    agent_vn2.load(_SAVE_PATH_VN, env=fresh_norm)
+    assert agent_vn2.model is not None
+    assert isinstance(agent_vn2.env, VecNormalize)
+    assert not agent_vn2.env.training, "VecNormalize should be frozen after load"
+    ok()
+except Exception as e:
+    fail(e)
+
+# ── 8. evaluate() ────────────────────────────────────────
+print("\n[8] evaluate() — 2 deterministic episodes")
+try:
+    step("Build single (non-vectorized) eval env")
+    eval_env = AuctionNetGymEnv(env_cfg)
+    ok()
+
+    step("agent.evaluate(eval_env, n_eval_episodes=2)")
+    metrics = agent.evaluate(eval_env, n_eval_episodes=2)
+    assert set(metrics.keys()) == {"roi", "budget_utilization", "win_rate"}, \
+        f"unexpected keys: {metrics.keys()}"
+    assert all(isinstance(v, float) for v in metrics.values()), \
+        "all metric values should be floats"
+    assert metrics["budget_utilization"] >= 0.0
+    assert metrics["win_rate"] >= 0.0
+    ok()
+    print(f"      roi                = {metrics['roi']:.4f}")
+    print(f"      budget_utilization = {metrics['budget_utilization']:.4f}")
+    print(f"      win_rate           = {metrics['win_rate']:.4f}")
+except Exception as e:
+    fail(e)
+
+# ── Cleanup ──────────────────────────────────────────────
+shutil.rmtree("saved_models", ignore_errors=True)
+
+print("\n" + "=" * 55)
+print("  All checks passed.")
+print("=" * 55)

--- a/test_agent.py
+++ b/test_agent.py
@@ -110,7 +110,7 @@ try:
     assert action.dtype in (np.float32, np.float64), f"unexpected dtype {action.dtype}"
     assert lp is None and val is None
     ok()
-    print(f"      action = {action.flatten()[0]:.4f}  (in [0, {env_cfg['max_bid_multiplier']}])")
+    print(f"      action = {action.flatten()[0]:.4f}  (in [-1, 1]; rescaled to [0, {env_cfg['max_bid_multiplier']}] in step())")
 
     step("select_action(obs, deterministic=True) — greedy")
     action_det, _, _ = agent.select_action(obs, deterministic=True)

--- a/test_env.py
+++ b/test_env.py
@@ -1,0 +1,138 @@
+"""
+Throwaway smoke test for AuctionNetGymEnv.
+Run from project root: python test_env.py
+Delete after confirming everything works.
+"""
+
+import sys
+
+def step(msg):
+    print(f"  [ ] {msg}", end="", flush=True)
+
+def ok():
+    print("\r  [x]", flush=True)
+
+def fail(e):
+    print(f"\r  [!] FAILED — {e}")
+    sys.exit(1)
+
+
+print("=" * 55)
+print("  AuctionNetGymEnv Smoke Test")
+print("=" * 55)
+
+# ── 1. Config ────────────────────────────────────────────
+print("\n[1] Loading config")
+try:
+    step("Reading configs/default.yaml")
+    import yaml
+    with open("configs/default.yaml") as f:
+        config = yaml.safe_load(f)["environment"]
+    # Override pv_num for smoke test — 1K PVs instead of 500K
+    config["pv_num"] = 1_000
+    ok()
+    print(f"      budget={config['budget']}, num_ticks={config['num_ticks']}, "
+          f"player_index={config['player_index']}, pv_num={config['pv_num']} (smoke test override)")
+except Exception as e:
+    fail(e)
+
+# ── 2. AuctionNet import ─────────────────────────────────
+print("\n[2] Accessing AuctionNet modules")
+try:
+    import sys, os
+    auctionnet_abs = os.path.normpath(
+        os.path.join(os.path.dirname(os.path.abspath(".")), "AuctionNet")
+    )
+    if auctionnet_abs not in sys.path:
+        sys.path.insert(0, auctionnet_abs)
+
+    step("Importing BiddingEnv")
+    from simul_bidding_env.Environment.BiddingEnv import BiddingEnv
+    ok()
+
+    step("Importing NeurIPSPvGen")
+    from simul_bidding_env.PvGenerator.NeurIPSPvGen import NeurIPSPvGen
+    ok()
+
+    step("Importing PidBiddingStrategy")
+    from simul_bidding_env.strategy.pid_bidding_strategy import PidBiddingStrategy
+    ok()
+
+    step("Importing PidBiddingStrategy (sole competitor — no model files needed)")
+    from simul_bidding_env.strategy.pid_bidding_strategy import PidBiddingStrategy
+    ok()
+except Exception as e:
+    fail(e)
+
+# ── 3. Environment init ──────────────────────────────────
+print("\n[3] Initialising AuctionNetGymEnv")
+try:
+    step("Importing wrapper")
+    from environment.gym_wrapper import AuctionNetGymEnv
+    ok()
+
+    step("Instantiating env (builds BiddingEnv, PvGen, 47 competitors)")
+    env = AuctionNetGymEnv(config)
+    ok()
+
+    step("Checking observation_space shape")
+    assert env.observation_space.shape == (7,), env.observation_space.shape
+    ok()
+
+    step("Checking action_space shape")
+    assert env.action_space.shape == (1,), env.action_space.shape
+    ok()
+except Exception as e:
+    fail(e)
+
+# ── 4. SB3 compliance ────────────────────────────────────
+print("\n[4] Running SB3 check_env")
+try:
+    step("check_env (verifies Gymnasium API contract)")
+    from stable_baselines3.common.env_checker import check_env
+    check_env(env)
+    ok()
+except Exception as e:
+    fail(e)
+
+# ── 5. Reset ─────────────────────────────────────────────
+print("\n[5] Resetting environment")
+try:
+    step("env.reset()")
+    obs, info = env.reset()
+    ok()
+    print(f"      obs shape : {obs.shape}")
+    print(f"      obs values: {obs}")
+except Exception as e:
+    fail(e)
+
+# ── 6. Episode rollout ───────────────────────────────────
+print("\n[6] Running one full episode (random actions)")
+print(f"  {'tick':>4}  {'won':>5}  {'cost':>8}  {'conv':>8}  {'reward':>8}  {'budget':>8}")
+print(f"  {'-'*4}  {'-'*5}  {'-'*8}  {'-'*8}  {'-'*8}  {'-'*8}")
+try:
+    total_reward = 0
+    for tick in range(48):
+        action = env.action_space.sample()
+        obs, reward, terminated, truncated, info = env.step(action)
+        total_reward += reward
+        print(
+            f"  {tick+1:>4}  "
+            f"{info['won']:>5}  "
+            f"{info['cost']:>8.2f}  "
+            f"{info['conversion_value']:>8.4f}  "
+            f"{reward:>8.4f}  "
+            f"{info['remaining_budget']:>8.2f}"
+        )
+        if terminated:
+            print(f"\n  Budget exhausted — episode ended at tick {tick+1}")
+            break
+except Exception as e:
+    fail(e)
+
+# ── Summary ──────────────────────────────────────────────
+print("\n" + "=" * 55)
+print(f"  Total reward : {total_reward:.4f}")
+print(f"  Final obs    : {obs}")
+print("  All checks passed.")
+print("=" * 55)


### PR DESCRIPTION
**This PR**
 - Adds Eric’s Implicit Q-Learning (IQL) implementation as an offline RL baseline.
- Wires IQL into the project’s training/eval entrypoints/configs so it’s runnable alongside PPO and fixed-bid baselines.
- Includes logging + metrics output to compare against existing baselines (ROI/“value-per-spend”, budget utilization, win rate, etc.).

**Why**
We need an offline RL baseline to benchmark PPO (online) and fixed-bid heuristics, and to support the project’s “Baselines & Metrics” evaluation plan.

